### PR TITLE
Only delete expired temporary bans, not perma bans

### DIFF
--- a/src/me/leoko/advancedban/manager/PunishmentManager.java
+++ b/src/me/leoko/advancedban/manager/PunishmentManager.java
@@ -55,7 +55,7 @@ public class PunishmentManager {
                     Universal.get().getMysql().executeSatement(sql);
                 }
 
-                Universal.get().getMysql().executeSatement("DELETE FROM `Punishments` WHERE `end` <= '"+TimeManager.getTime()+"'");
+                Universal.get().getMysql().executeSatement("DELETE FROM `Punishments` WHERE `end` <= '"+TimeManager.getTime()+"' AND `punishmentType` = 'TEMP_BAN'");
                 ResultSet rs = Universal.get().getMysql().executeRespSatemen("SELECT * FROM `Punishments`");
                 while(rs.next()) {
                     punishments.add(


### PR DESCRIPTION
Make sure that you're only deleting temporary bans and not permanent ones - permanent bans will always be considered "expired" since they always use an "end" value of -1, so the current query will always delete them.