### PR TITLE
Fix for MySQL Port Changing Main connect method

### DIFF
--- a/src/me/leoko/advancedban/manager/MySQLManager.java
+++ b/src/me/leoko/advancedban/manager/MySQLManager.java
@@ -89,7 +89,7 @@ public class MySQLManager {
 	
 	private void connect(){
 		try{
-			connection = DriverManager.getConnection("jdbc:mysql://"+ip+":3306/"+dbName, usrName, password);
+			connection = DriverManager.getConnection("jdbc:mysql://"+ip+":"+port+"/"+dbName, usrName, password);
 		}catch(Exception exc){
 			System.out.println("AdvancedBan <> \n \n \nMySQL-Error\nCould not connect to MySQL-Server!\nDisabeling plugin!\nCheck your MySQL.yml \nSkype: Leoko33 \n \n");
 			failed = true;


### PR DESCRIPTION
Noticed an error in the main MySQL connect method, where it doesn't add support for a custom port until the reconnect method, and since we don't want people complaining, figured I should add the quick fix and add the custom port in.