### PR TITLE
Tab Complete Rewrite

### DIFF
--- a/src/me/leoko/advancedban/bungee/listener/CommandReceiverBungee.java
+++ b/src/me/leoko/advancedban/bungee/listener/CommandReceiverBungee.java
@@ -22,6 +22,18 @@ public class CommandReceiverBungee extends Command implements TabExecutor{
 
     @Override
     public Iterable<String> onTabComplete(CommandSender commandSender, String[] strings) {
-        return BungeeMain.get().getOnlinePlayers();
+        Set<String> matches = new HashSet<>();
++        if ( args.length == 1 )
++        {
++            String search = args[0].toLowerCase();
++            for ( String player : BungeeMain.getOnlinePlayers() )
++            {
++                if ( player.toLowerCase().startsWith( search ) )
++                {
++                    matches.add( player );
++                }
++            }
++        }
+        return matches;
     }
 }

--- a/src/me/leoko/advancedban/bungee/listener/CommandReceiverBungee.java
+++ b/src/me/leoko/advancedban/bungee/listener/CommandReceiverBungee.java
@@ -6,6 +6,9 @@ import net.md_5.bungee.api.CommandSender;
 import net.md_5.bungee.api.plugin.Command;
 import net.md_5.bungee.api.plugin.TabExecutor;
 
+import java.util.HashSet;
+import java.util.Set;
+
 /**
  * Created by Leoko @ dev.skamps.eu on 24.07.2016.
  */
@@ -23,17 +26,14 @@ public class CommandReceiverBungee extends Command implements TabExecutor{
     @Override
     public Iterable<String> onTabComplete(CommandSender commandSender, String[] strings) {
         Set<String> matches = new HashSet<>();
-+        if ( args.length == 1 )
-+        {
-+            String search = args[0].toLowerCase();
-+            for ( String player : BungeeMain.getOnlinePlayers() )
-+            {
-+                if ( player.toLowerCase().startsWith( search ) )
-+                {
-+                    matches.add( player );
-+                }
-+            }
-+        }
+        if (strings.length == 1) {
+            String search = strings[0].toLowerCase();
+            for (String player : BungeeMain.get().getOnlinePlayers()) {
+                if (player.toLowerCase().startsWith(search)){
+                    matches.add(player);
+                }
+            }
+        }
         return matches;
     }
 }


### PR DESCRIPTION
As it has been noted in issue #44, BungeeCord versions are having issues tab completing player names. While I have very little development skills for BungeeCord, theoretically, this should fix the issue and allow players to be tab completed based on text already given, as long as there is only 1 argument. A dev or Leoko can comment on other fixes for this, but I figured it was a quick fix, so why not. :)