### PR TITLE
[~] Fixed Imports

### DIFF
--- a/src/me/leoko/advancedban/bungee/listener/ChatListenerBungee.java
+++ b/src/me/leoko/advancedban/bungee/listener/ChatListenerBungee.java
@@ -1,7 +1,6 @@
 package me.leoko.advancedban.bungee.listener;
 
 import me.leoko.advancedban.Universal;
-import net.md_5.bungee.UserConnection;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.md_5.bungee.api.event.ChatEvent;
 import net.md_5.bungee.api.plugin.Listener;

--- a/src/me/leoko/advancedban/bungee/listener/ConnectionListenerBungee.java
+++ b/src/me/leoko/advancedban/bungee/listener/ConnectionListenerBungee.java
@@ -2,8 +2,6 @@ package me.leoko.advancedban.bungee.listener;
 
 import me.leoko.advancedban.Universal;
 import net.md_5.bungee.api.ProxyServer;
-import net.md_5.bungee.api.connection.ProxiedPlayer;
-import net.md_5.bungee.api.event.LoginEvent;
 import net.md_5.bungee.api.event.PostLoginEvent;
 import net.md_5.bungee.api.plugin.Listener;
 import net.md_5.bungee.event.EventHandler;

--- a/src/me/leoko/advancedban/listener/CommandListener.java
+++ b/src/me/leoko/advancedban/listener/CommandListener.java
@@ -1,14 +1,10 @@
 package me.leoko.advancedban.listener;
 
-import me.leoko.advancedban.BukkitMain;
 import me.leoko.advancedban.Universal;
-import me.leoko.advancedban.manager.PunishmentManager;
-import me.leoko.advancedban.manager.UUIDManager;
-import me.leoko.advancedban.utils.Punishment;
+
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
-import org.bukkit.event.player.AsyncPlayerChatEvent;
 import org.bukkit.event.player.PlayerCommandPreprocessEvent;
 
 /**


### PR DESCRIPTION
After attempting to compile my own version of AdvancedBan for someone on here, my IDE has given me warnings about unused imports, so I removed them and added them to a commit to add here. Also, just a note, after attempting to compile against 1.11.2 Spigot and a 1.11 build of BungeeCord, I have come to find a considerable amount of methods are deprecated. I did not add deprecated tags do to possible breakage, but I figured that you should know.