### PR TITLE
FIX Warning MYSQL SSL CERT

### DIFF
--- a/src/me/leoko/advancedban/manager/MySQLManager.java
+++ b/src/me/leoko/advancedban/manager/MySQLManager.java
@@ -89,7 +89,7 @@ public class MySQLManager {
 	
 	private void connect(){
 		try{
-			connection = DriverManager.getConnection("jdbc:mysql://"+ip+":3306/"+dbName, usrName, password);
+			connection = DriverManager.getConnection("jdbc:mysql://"+ip+":3306/"+dbName+"?verifyServerCertificate=false&useSSL=false", usrName, password);
 		}catch(Exception exc){
 			System.out.println("AdvancedBan <> \n \n \nMySQL-Error\nCould not connect to MySQL-Server!\nDisabeling plugin!\nCheck your MySQL.yml \nSkype: Leoko33 \n \n");
 			failed = true;


### PR DESCRIPTION
**Error on BungeeCord & Spigot using MySQL DB:**
"For compliance with existing applications not using SSL the verifyServerCertificate property is set to 'false'. You need either to explicitly disable SSL by setting useSSL=false, or set useSSL=true and provide truststore for server certificate verification."

**I have changed this params for temporal fix:**
"verifyServerCertificate" property is set to 'false'.
"useSSL" property is set to 'false'.

You can add "useSSL" property to the config of plugin for user's use a SSL Cert.

Please update ASAP!
Thanks