### PR TITLE
Allow compatibility with FastLogin and similar plugins and fix for bungeecord tab completion

### DIFF
--- a/src/main/java/me/leoko/advancedban/bungee/listener/ChatListenerBungee.java
+++ b/src/main/java/me/leoko/advancedban/bungee/listener/ChatListenerBungee.java
@@ -13,8 +13,8 @@ import net.md_5.bungee.event.EventHandler;
  * Created by Leoko @ dev.skamps.eu on 24.07.2016.
  */
 public class ChatListenerBungee implements Listener {
-	
-	@EventHandler
+
+    @EventHandler
     public void onChat(ChatEvent event) {
         if (!(event.getSender() instanceof ProxiedPlayer)) {
             return;
@@ -29,9 +29,18 @@ public class ChatListenerBungee implements Listener {
             }
         }
     }
-    
+
     @EventHandler
     public void onTabComplete(TabCompleteEvent event) {
+        String cursor = event.getCursor().toLowerCase();
+        if (!(cursor.startsWith("/ban ") || cursor.startsWith("/ban-ip ") || cursor.startsWith("/banip ")
+                || cursor.startsWith("/check ") || cursor.startsWith("/history ") || cursor.startsWith("/ipban ")
+                || cursor.startsWith("/kick ") || cursor.startsWith("/mute ") || cursor.startsWith("/tempban ")
+                || cursor.startsWith("/tempipban ") || cursor.startsWith("/tempmute ") || cursor.startsWith("/tempwarn ")
+                || cursor.startsWith("/tipban ") || cursor.startsWith("/unmute ") || cursor.startsWith("/unwarn ")
+                || cursor.startsWith("/warn "))) {
+            return;
+        }
         if (event.getSender() instanceof ProxiedPlayer) { // Check if the player has permission for tab complete
             ProxiedPlayer pp = (ProxiedPlayer) event.getSender();
             boolean deny = false;
@@ -51,20 +60,10 @@ public class ChatListenerBungee implements Listener {
                 return;
             }
         }
-        String cursor = event.getCursor().toLowerCase();
-        
-        if (!(cursor.startsWith("/ban ") || cursor.startsWith("/ban-ip ") || cursor.startsWith("/banip ") 
-        		|| cursor.startsWith("/check ") || cursor.startsWith("/history ") || cursor.startsWith("/ipban ") 
-        		|| cursor.startsWith("/kick ") || cursor.startsWith("/mute ") || cursor.startsWith("/tempban ") 
-        		|| cursor.startsWith("/tempipban ") || cursor.startsWith("/tempmute ") || cursor.startsWith("/tempwarn ") 
-        		|| cursor.startsWith("/tipban ") || cursor.startsWith("/unmute ") || cursor.startsWith("/unwarn ") 
-        		|| cursor.startsWith("/warn "))) {
-            return;
-        }
-        
+
         String[] split = cursor.split(" ");
         String partialPlayerName = split[split.length - 1];
-        
+
         for (ProxiedPlayer p : BungeeMain.get().getProxy().getPlayers()) {
             if (p.getName().toLowerCase().startsWith(partialPlayerName)) {
                 event.getSuggestions().add(p.getName());

--- a/src/main/java/me/leoko/advancedban/bungee/listener/ConnectionListenerBungee.java
+++ b/src/main/java/me/leoko/advancedban/bungee/listener/ConnectionListenerBungee.java
@@ -5,19 +5,20 @@ import me.leoko.advancedban.Universal;
 import me.leoko.advancedban.bungee.BungeeMain;
 import me.leoko.advancedban.manager.PunishmentManager;
 import net.md_5.bungee.api.ProxyServer;
+import net.md_5.bungee.api.event.LoginEvent;
 import net.md_5.bungee.api.event.PlayerDisconnectEvent;
 import net.md_5.bungee.api.event.PostLoginEvent;
-import net.md_5.bungee.api.event.PreLoginEvent;
 import net.md_5.bungee.api.plugin.Listener;
 import net.md_5.bungee.event.EventHandler;
+import net.md_5.bungee.event.EventPriority;
 
 /**
  * Created by Leoko @ dev.skamps.eu on 24.07.2016.
  */
 public class ConnectionListenerBungee implements Listener {
 
-    @EventHandler
-    public void onConnection(PreLoginEvent event) {
+    @EventHandler(priority = EventPriority.LOW)
+    public void onConnection(LoginEvent event) {
         event.registerIntent((BungeeMain)Universal.get().getMethods().getPlugin());
         Universal.get().getMethods().runAsync(() -> {
             String result = Universal.get().callConnection(event.getConnection().getName(), event.getConnection().getAddress().getAddress().getHostAddress());


### PR DESCRIPTION
The punishment checking (that includes IP and UUID caching) should be later to allow compatibility with plugins that edit the UUID of the player. (Closes #183) 
It also fixes a bug with tab completion in bungeecord that prevents any tab completion if the user hasn't permission to use any punishment command.