### PR TITLE
Allow for MariaDB Driver

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,11 @@
             <version>5.0.0-RC2</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mariadb.jdbc</groupId>
+            <artifactId>mariadb-java-client</artifactId>
+            <version>2.2.3</version>
+        </dependency>
     </dependencies>
     <build>
         <finalName>${project.artifactId}-${project.version}</finalName>

--- a/src/main/java/me/leoko/advancedban/Universal.java
+++ b/src/main/java/me/leoko/advancedban/Universal.java
@@ -46,7 +46,7 @@ public class Universal {
         UUIDManager.get().setup();
 
         try {
-            DatabaseManager.get().setup(mi.getBoolean(mi.getConfig(), "UseMySQL", false));
+            DatabaseManager.get().setup(mi.getBoolean(mi.getConfig(), "UseMySQL", false), mi.getBoolean(mi.getConfig(), "UseMariaDBDriver", false));
         } catch (Exception ex) {
             log("Failed enabling database-manager...");
             debug(ex.getMessage());

--- a/src/main/java/me/leoko/advancedban/manager/DatabaseManager.java
+++ b/src/main/java/me/leoko/advancedban/manager/DatabaseManager.java
@@ -28,7 +28,7 @@ public class DatabaseManager {
         return instance == null ? instance = new DatabaseManager() : instance;
     }
 
-    public void setup(boolean useMySQLServer) {
+    public void setup(boolean useMySQLServer, boolean useMariaDBDriver) {
         MethodInterface mi = Universal.get().getMethods();
 
         if (useMySQLServer) {
@@ -55,7 +55,7 @@ public class DatabaseManager {
                 password = mi.getString(mi.getMySQLFile(), "MySQL.Password", "Unknown");
                 port = mi.getInteger(mi.getMySQLFile(), "MySQL.Port", 3306);
 
-                connectMySQLServer();
+                connectMySQLServer(useMariaDBDriver);
             }
         }
 
@@ -100,21 +100,39 @@ public class DatabaseManager {
         }
     }
 
-    private void connectMySQLServer() {
-        try {
-            connection = DriverManager.getConnection("jdbc:mysql://" + ip + ":" + port + "/" + dbName + "?verifyServerCertificate=false&useSSL=false&autoReconnect=true", usrName, password);
-        } catch (SQLException exc) {
-            Universal.get().log(
-                    " \n"
-                    + " MySQL-Error\n"
-                    + " Could not connect to MySQL-Server!\n"
-                    + " Disabling plugin!\n"
-                    + " Check your MySQL.yml\n"
-                    + " Skype: Leoko33\n"
-                    + " Issue tracker: https://github.com/DevLeoko/AdvancedBan/issues \n"
-                    + " \n"
-            );
-            failedMySQL = true;
+    private void connectMySQLServer(boolean useMariaDBDriver) {
+        if (useMariaDBDriver) {
+            try {
+                connection = DriverManager.getConnection("jdbc:mariadb://" + ip + ":" + port + "/" + dbName + "?verifyServerCertificate=false&useSSL=false&autoReconnect=true", usrName, password);
+            } catch (SQLException exc) {
+                Universal.get().log(
+                        " \n"
+                        + " MariaDB-Error\n"
+                        + " Could not connect to MySQL-Server!\n"
+                        + " Disabling plugin!\n"
+                        + " Check your MySQL.yml\n"
+                        + " Skype: Leoko33\n"
+                        + " Issue tracker: https://github.com/DevLeoko/AdvancedBan/issues \n"
+                        + " \n"
+                );
+                failedMySQL = true;
+            }
+        } else {
+            try {
+                connection = DriverManager.getConnection("jdbc:mysql://" + ip + ":" + port + "/" + dbName + "?verifyServerCertificate=false&useSSL=false&autoReconnect=true&disableMariaDbDriver", usrName, password);
+            } catch (SQLException exc) {
+                Universal.get().log(
+                        " \n"
+                        + " MySQL-Error\n"
+                        + " Could not connect to MySQL-Server!\n"
+                        + " Disabling plugin!\n"
+                        + " Check your MySQL.yml\n"
+                        + " Skype: Leoko33\n"
+                        + " Issue tracker: https://github.com/DevLeoko/AdvancedBan/issues \n"
+                        + " \n"
+                );
+                failedMySQL = true;
+            }
         }
     }
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -6,6 +6,13 @@
 
 # If set to false all bans will be saved locally in a HSQLDB-Database
 UseMySQL: false
+# If UseMySQL is set to true and you run a MariaDB server
+# Set this to true to use the MariaDB JDBC Driver over
+# The normal MySQL JConnector. This only works if you have
+# a MariaDB server instead of the Oracle MySQL server.
+# It is heavily recommended to use MariaDB over the Oracle Server
+# See more here: https://mariadb.com/resources/blog/mariadb-java-connector-driver-performance
+UseMariaDBDriver: false
 
 # Set to false if you want to have only short messages in the console
 # On startup and on the shutdown.


### PR DESCRIPTION
https://mariadb.com/resources/blog/mariadb-java-connector-driver-performance

The performance improvement may not actually be that much for something
as simple as a Ban plugin, but it is nice to have it as an option for
far reaching servers that have the SQL server across the world.