### PR TITLE
bstats: Fix build by changing bstats repo and updating to version 1.5

### DIFF
--- a/bukkit/pom.xml
+++ b/bukkit/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>org.bstats</groupId>
             <artifactId>bstats-bukkit</artifactId>
-            <version>1.2</version>
+            <version>1.5</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/bungee/pom.xml
+++ b/bungee/pom.xml
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>org.bstats</groupId>
             <artifactId>bstats-bungeecord</artifactId>
-            <version>1.2</version>
+            <version>1.5</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -27,8 +27,8 @@
 
     <repositories>
         <repository>
-            <id>bstats-repo</id>
-            <url>http://repo.bstats.org/content/repositories/releases/</url>
+            <id>CodeMC</id>
+            <url>https://repo.codemc.org/repository/maven-public</url>
         </repository>
         <repository>
             <id>md_5-snapshots</id>


### PR DESCRIPTION
http://repo.bstats.org seems to be down, so I've updated the repo URL to the
new one found at https://bstats.org/getting-started/include-metrics .
Moreover, I've upgraded the bstats version to `1.5` as `1.2` is no longer
available on the new repository server.

**TL;DR**
This basically allows the CI (and users) to build AdvancedBan again.

Feedback / changes very welcome <3