### PR TITLE
Synchronise Connection Access

### DIFF
--- a/src/main/java/me/leoko/advancedban/manager/DatabaseManager.java
+++ b/src/main/java/me/leoko/advancedban/manager/DatabaseManager.java
@@ -18,6 +18,8 @@ import java.sql.*;
  */
 public class DatabaseManager {
 
+	private final Object lock = new Object();
+	
     private String ip;
     private String dbName;
     private String usrName;
@@ -162,35 +164,37 @@ public class DatabaseManager {
     }
 
     private ResultSet executeStatement(String sql, boolean result, Object... parameters) {
-        try (PreparedStatement statement = connection.prepareStatement(sql)) {
-
-            for (int i = 0; i < parameters.length; i++) {
-                Object obj = parameters[i];
-                if (obj instanceof Integer) {
-                    statement.setInt(i + 1, (Integer) obj);
-                } else if (obj instanceof String) {
-                    statement.setString(i + 1, (String) obj);
-                } else if (obj instanceof Long) {
-                    statement.setLong(i + 1, (Long) obj);
-                } else {
-                    statement.setObject(i + 1, obj);
-                }
-            }
-
-            if (result) {
-                return statement.executeQuery();
-            }
-			statement.execute();
-        } catch (SQLException ex) {
-            Universal.get().log(
-                    "An unexpected error has occurred executing an Statement in the database\n"
-                    + "Please check the plugins/AdvancedBan/logs/latest.log file and report this"
-                    + "error in: https://github.com/DevLeoko/AdvancedBan/issues"
-            );
-            Universal.get().debug("Query: \n" + sql);
-            Universal.get().debug(ex);
-        }
-        return null;
+    	synchronized (lock) {
+    		try (PreparedStatement statement = connection.prepareStatement(sql)) {
+    			
+    			for (int i = 0; i < parameters.length; i++) {
+    				Object obj = parameters[i];
+    				if (obj instanceof Integer) {
+    					statement.setInt(i + 1, (Integer) obj);
+    				} else if (obj instanceof String) {
+    					statement.setString(i + 1, (String) obj);
+    				} else if (obj instanceof Long) {
+    					statement.setLong(i + 1, (Long) obj);
+    				} else {
+    					statement.setObject(i + 1, obj);
+    				}
+    			}
+    			
+    			if (result) {
+    				return statement.executeQuery();
+    			}
+    			statement.execute();
+    		} catch (SQLException ex) {
+    			Universal.get().log(
+    					"An unexpected error has occurred executing an Statement in the database\n"
+    							+ "Please check the plugins/AdvancedBan/logs/latest.log file and report this"
+    							+ "error in: https://github.com/DevLeoko/AdvancedBan/issues"
+    					);
+    			Universal.get().debug("Query: \n" + sql);
+    			Universal.get().debug(ex);
+        	}
+        	return null;
+    	}
     }
 
     /**

--- a/src/main/java/me/leoko/advancedban/manager/DatabaseManager.java
+++ b/src/main/java/me/leoko/advancedban/manager/DatabaseManager.java
@@ -168,16 +168,7 @@ public class DatabaseManager {
     		try (PreparedStatement statement = connection.prepareStatement(sql)) {
     			
     			for (int i = 0; i < parameters.length; i++) {
-    				Object obj = parameters[i];
-    				if (obj instanceof Integer) {
-    					statement.setInt(i + 1, (Integer) obj);
-    				} else if (obj instanceof String) {
-    					statement.setString(i + 1, (String) obj);
-    				} else if (obj instanceof Long) {
-    					statement.setLong(i + 1, (Long) obj);
-    				} else {
-    					statement.setObject(i + 1, obj);
-    				}
+    				statement.setObject(i + 1, parameters[i]);
     			}
     			
     			if (result) {

--- a/src/main/java/me/leoko/advancedban/manager/DatabaseManager.java
+++ b/src/main/java/me/leoko/advancedban/manager/DatabaseManager.java
@@ -17,8 +17,6 @@ import java.sql.*;
  * {@link PunishmentManager#getPunishmentFromResultSet(ResultSet)} for already parsed data.
  */
 public class DatabaseManager {
-
-	private final Object lock = new Object();
 	
     private String ip;
     private String dbName;
@@ -163,29 +161,27 @@ public class DatabaseManager {
         return executeStatement(sql.toString(), result, parameters);
     }
 
-    private ResultSet executeStatement(String sql, boolean result, Object... parameters) {
-    	synchronized (lock) {
-    		try (PreparedStatement statement = connection.prepareStatement(sql)) {
-    			
-    			for (int i = 0; i < parameters.length; i++) {
-    				statement.setObject(i + 1, parameters[i]);
-    			}
-    			
-    			if (result) {
-    				return statement.executeQuery();
-    			}
-    			statement.execute();
-    		} catch (SQLException ex) {
-    			Universal.get().log(
-    					"An unexpected error has occurred executing an Statement in the database\n"
-    							+ "Please check the plugins/AdvancedBan/logs/latest.log file and report this"
-    							+ "error in: https://github.com/DevLeoko/AdvancedBan/issues"
-    					);
-    			Universal.get().debug("Query: \n" + sql);
-    			Universal.get().debug(ex);
-        	}
-        	return null;
-    	}
+    private synchronized ResultSet executeStatement(String sql, boolean result, Object... parameters) {
+    	try (PreparedStatement statement = connection.prepareStatement(sql)) {
+    		
+    		for (int i = 0; i < parameters.length; i++) {
+    			statement.setObject(i + 1, parameters[i]);
+    		}
+   			
+    		if (result) {
+    			return statement.executeQuery();
+    		}
+   			statement.execute();
+    	} catch (SQLException ex) {
+    		Universal.get().log(
+   					"An unexpected error has occurred executing an Statement in the database\n"
+   							+ "Please check the plugins/AdvancedBan/logs/latest.log file and report this"
+    						+ "error in: https://github.com/DevLeoko/AdvancedBan/issues"
+    				);
+    		Universal.get().debug("Query: \n" + sql);
+    		Universal.get().debug(ex);
+       	}
+        return null;
     }
 
     /**


### PR DESCRIPTION
**What we know about** #203 

- Happens only with MySQL external storage mode
- Does not happen on every player login.

**Why Synchronise**

`Connection` objects are not thread-safe per multiple StackOverflow answers. Synchronisation is very simple yet very important. Even if this is not the fix to #203 , it is still good practice to use mutual exclusion in multi-threaded environments.

According to several StackOverflow answers, `Connection` objects are not thread-safe for MySQL JDBC (but possibly thread-safe in later versions). According to another user, connections are thread-safe if the driver is compliant with the SQL standard. MySQL does not comply with the standard, which is likely why their connection is not thread-safe. HSQLDB touts full compliance. This would explain why #203 only occurs with MySQL.

**Why This May Not Fix 203**
Concurrency problems may arise if multiple threads access a single state simultaneously. AsyncPlayerPreLoginEvent is asynchronous and may thus give rise to such errors. However, as a prerequisite, multiple threads must access the same state very quickly. I have encountered #203 in environments where it did not seem that the connection object would be used often.

Nevertheless, synchronisation should be performed when accessing JDBC `Connection` objects, even if the synchronisation does not fix #203 .