### PR TITLE
Add support for old notification permissions

### DIFF
--- a/src/main/java/me/leoko/advancedban/MethodInterface.java
+++ b/src/main/java/me/leoko/advancedban/MethodInterface.java
@@ -400,8 +400,22 @@ public interface MethodInterface {
      * @param perm         the perm
      * @param notification the notification
      */
-    void notify(String perm, List<String> notification);
-
+    default void notify(String perm, List<String> notification) {
+    	notify(perm, null, notification);
+    }
+    
+    /**
+     * Broadcast a message to every user with the given perm OR the alt perm.
+     * Effort is made to ensure that the same message is not sent twice
+     * if the user has both permissions, but this is not guaranteed
+     * on all implementations.
+     * 
+     * @param perm the permission
+     * @param altPerm the alternate permission, can be <code>null</code>
+     * @param notification the notification
+     */
+    void notify(String perm, String altPerm, List<String> notification);
+    
     /**
      * Log a message.
      *

--- a/src/main/java/me/leoko/advancedban/bukkit/BukkitMethods.java
+++ b/src/main/java/me/leoko/advancedban/bukkit/BukkitMethods.java
@@ -361,9 +361,9 @@ public class BukkitMethods implements MethodInterface {
     }
 
     @Override
-    public void notify(String perm, List<String> notification) {
+    public void notify(String perm, String altPerm, List<String> notification) {
         for (Player p : Bukkit.getOnlinePlayers()) {
-            if (hasPerms(p, perm)) {
+            if (hasPerms(p, perm) || altPerm != null && hasPerms(p, altPerm)) {
                 for (String str : notification) {
                     sendMessage(p, str);
                 }

--- a/src/main/java/me/leoko/advancedban/bungee/BungeeMethods.java
+++ b/src/main/java/me/leoko/advancedban/bungee/BungeeMethods.java
@@ -388,13 +388,16 @@ public class BungeeMethods implements MethodInterface {
     }
 
     @Override
-    public void notify(String perm, List<String> notification) {
-        if (Universal.get().useRedis()) {
+    public void notify(String perm, String altPerm, List<String> notification) {
+    	if (Universal.get().useRedis()) {
             notification.forEach((str) -> {
                 RedisBungee.getApi().sendChannelMessage("AdvancedBan", "notification " + perm + " " + str);
+                if (altPerm != null) {
+                	RedisBungee.getApi().sendChannelMessage("AdvancedBan", "notification " + altPerm + " " + str);
+                }
             });
         } else {
-            ProxyServer.getInstance().getPlayers().stream().filter((pp) -> (Universal.get().hasPerms(pp, perm))).forEachOrdered((pp) -> {
+            ProxyServer.getInstance().getPlayers().stream().filter((pp) -> (Universal.get().hasPerms(pp, perm) || altPerm != null && Universal.get().hasPerms(pp, altPerm))).forEachOrdered((pp) -> {
                 notification.forEach((str) -> {
                     sendMessage(pp, str);
                 });

--- a/src/main/java/me/leoko/advancedban/utils/Punishment.java
+++ b/src/main/java/me/leoko/advancedban/utils/Punishment.java
@@ -185,7 +185,7 @@ public class Punishment {
                 "DATE", getDate(start),
                 "COUNT", cWarnings + "");
 
-        mi.notify("ab.notify." + getType().getName(), notification);
+        mi.notify("ab.notify." + getType().getName(), "ab." + getType().getName() + ".notify", notification);
     }
 
     public void delete() {
@@ -213,7 +213,7 @@ public class Punishment {
         if (who != null) {
             String message = MessageManager.getMessage("Un" + getType().getBasic().getConfSection("Notification"),
                     true, "OPERATOR", who, "NAME", getName());
-            mi.notify("ab.undoNotify." + getType().getBasic().getName(), Collections.singletonList(message));
+            mi.notify("ab.undoNotify." + getType().getBasic().getName(), "ab." + getType().getBasic().getName() + ".undoNotify", Collections.singletonList(message));
 
             Universal.get().debug(who + " is deleting a punishment");
         }

--- a/src/test/java/me/leoko/advancedban/TestMethods.java
+++ b/src/test/java/me/leoko/advancedban/TestMethods.java
@@ -293,7 +293,7 @@ public class TestMethods implements MethodInterface {
     }
 
     @Override
-    public void notify(String perm, List<String> notification) {
+    public void notify(String perm, String altPerm, List<String> notification) {
         notification.forEach(System.out::println);
     }
 


### PR DESCRIPTION
Ensures the notification permission format, ab.TYPE.notify and ab.TYPE.undoNotify, continue to work on older server configurations. _TYPE_ is any `PunishmentType`.

To avoid breaking changes to MethodInterface calls, MethodInterface#notify(String, List) is retained. MI implementations, of course, must unavoidably be updated to support #notify(String, String, List).

Every effort is made to ensure that, if a player has both permissions from both formats, he or she will not receive two notification messages. For example, if a player has permission `ab.ban.notify` and `ab.notify.ban`, the player should not receive two messages. However, this behaviour, is not guaranteed in all MI implementations (on BungeeCord + Redis, the message would be sent twice).