### PR TITLE
Ignore Cancelled Login Events

### DIFF
--- a/src/main/java/me/leoko/advancedban/bukkit/listener/ConnectionListener.java
+++ b/src/main/java/me/leoko/advancedban/bukkit/listener/ConnectionListener.java
@@ -15,7 +15,7 @@ import org.bukkit.event.player.PlayerQuitEvent;
  * Created by Leoko @ dev.skamps.eu on 16.07.2016.
  */
 public class ConnectionListener implements Listener {
-    @EventHandler(priority = EventPriority.HIGHEST)
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onConnect(AsyncPlayerPreLoginEvent event) {
         String result = Universal.get().callConnection(event.getName(), event.getAddress().getHostAddress());
         if (result != null) {

--- a/src/main/java/me/leoko/advancedban/bungee/listener/ConnectionListenerBungee.java
+++ b/src/main/java/me/leoko/advancedban/bungee/listener/ConnectionListenerBungee.java
@@ -20,18 +20,20 @@ public class ConnectionListenerBungee implements Listener {
     @SuppressWarnings("deprecation")
 	@EventHandler(priority = EventPriority.LOW)
     public void onConnection(LoginEvent event) {
-        event.registerIntent((BungeeMain)Universal.get().getMethods().getPlugin());
-        Universal.get().getMethods().runAsync(() -> {
-            String result = Universal.get().callConnection(event.getConnection().getName(), event.getConnection().getAddress().getAddress().getHostAddress());
-            if (result != null) {
-                event.setCancelled(true);
-                event.setCancelReason(result);
-            }
-            if (Universal.get().useRedis()) {
-                RedisBungee.getApi().sendChannelMessage("AdvancedBanConnection", event.getConnection().getName() + "," + event.getConnection().getAddress().getAddress().getHostAddress());
-            }
-            event.completeIntent((BungeeMain)Universal.get().getMethods().getPlugin());
-        });
+    	if (!event.isCancelled()) {
+            event.registerIntent((BungeeMain)Universal.get().getMethods().getPlugin());
+            Universal.get().getMethods().runAsync(() -> {
+                String result = Universal.get().callConnection(event.getConnection().getName(), event.getConnection().getAddress().getAddress().getHostAddress());
+                if (result != null) {
+                    event.setCancelled(true);
+                    event.setCancelReason(result);
+                }
+                if (Universal.get().useRedis()) {
+                    RedisBungee.getApi().sendChannelMessage("AdvancedBanConnection", event.getConnection().getName() + "," + event.getConnection().getAddress().getAddress().getHostAddress());
+                }
+                event.completeIntent((BungeeMain)Universal.get().getMethods().getPlugin());
+            });
+    	}
     }
 
     @EventHandler


### PR DESCRIPTION
**Introduction**

Currently, AdvancedBan will listen to player logins and determine whether the player is banned. If so, the event is cancelled. However, this isn't a cheap operation; it necessitates a SQL connection to retrieve the InterimData for the player.

As "JHarris" asked out on the Discord:

> Could you confirm that your plugin has highest priority on login and check if the event is cancelled before running any code. Bot attacks seem to be successful with this plugin installed as code is run even if the bot is denied entry to the server and it ends up crashing

**The Issue is Not So Simple**

A premature solution would be to _simply_ ignore cancelled login events. Such would prevent the ConnectionListener (Spigot) and BungeeConnectionListener from running any logic if the event is already cancelled.

However, there persists a problem with _simply_ ignoring cancelled login events. Namely, while a login event may be cancelled and thus ignored by AdvancedBan, the event may be un-cancelled and the player may still login, after which point AdvancedBan has not cached the punishment data; however, in listening for mutes, AdvancedBan will, via the PunishmentManager, sometimes synchronously, query the database regarding the same user. The issue may be demonstrated with the following chains of events:

Current situation:

1. Player begins logging in.
2. AdvancedBan loads InterimData. On Spigot, the event is asynchronous, so it's OK (although sub-optimal) that the database query blocks the login thread temporarily. On BungeeCord, the event is also asynchronous; additionally, the plugin intention framework makes the process more efficient.
3. Player is not banned, so InterimData is stored via InterimData#accept().
4. Player attempts to chat. PunishmentManager has player's data cached, so there is no problem.
5. Player runs a command. PunishmentManager has player's data cached, so there is no problem.

Problematic situation, if _simple_ solution is implemented:

1. Player begins logging in.
2. Another plugin cancels the event. Even if AdvancedBan is set to LOWEST priority, another plugin could also be set to LOWEST priority, and therefore run before AdvancedBan.
3. AdvancedBan ignores the event, so it does not load InterimData. Nothing is cached.
4. Yet another plugin un-cancels the event. Even if AdvancedBan is set to HIGHEST priority, another plugin could also be set to HIGHEST priority, and therefore run after AdvancedBan.
5. Player attempts to chat. PunishmentManager is forced to retrieve the player's data from the database because it is not cached. (MethodInterface#callChat -> PunishmentManager#getMute -> PunishmentManager#getPunishments, and `isCached(target)` is false). This is not a disaster – the chat event still runs asynchronously (AsyncPlayerChatEvent). However, it does mean that the player will experience a momentary delay every time he or she chats, because AdvancedBan is continuously checking for mutes, from the database, each time.
6. Player runs a command. PunishmentManager is forced to retrieve the player's data from the database because it is not cached. (MethodInterface#callCMD -> PunishmentManager#getMute -> PunishmentManager#getPunishments, and `isCached(target)` is false). However, PlayerCommandPreProcessEvent is synchronous! This is a disaster, because AdvancedBan will block the main thread every time a player runs a command.

While somewhat rare, the second situation should be avoided at great cost. Accordingly, the solution is more complicated than merely ignoring cancelled events.

**A Better Solution**

Ideally, AdvancedBan would find a way to:

1. Avoid unnecessary calculations during a possible bot attack.
2. Maintain punishment caching in all potential scenarios where players are logged in and online.

While I'm working on this, the PR should remain a draft PR.