### PR TITLE
Register permissions with commands

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -6,43 +6,63 @@ author: Leoko
 commands:
   AdvancedBan:
     description: Information about the Plugin
+    permission: ab.help
   ban:
     description: Ban a user permanently
+    permission: ab.ban.perma
   tempban:
     description: Ban a user temporarily
+    permission: ab.ban.temp
   ipban:
     description: Ban a user by IP
     aliases: [banip, ban-ip]
+    permission: ab.ipban.perma
   tempipban:
     description: Ban a user temporarily by IP
     aliases: [tipban]
+    permission: ab.ipban.temp
   kick:
     description: Kick a user
+    permission: ab.kick
   warn:
     description: Warn a user permanently
+    permission: ab.warn.perma
   tempwarn:
     description: Warn a user temporarily
+    permission: ab.warn.temp
   mute:
     description: Mute a user permanently
+    permission: ab.mute.perma
   tempmute:
     description: Mute a user temporarily
+    permission: ab.mute.temp
   banlist:
     description: See all punishments
+    permission: ab.banlist
   history:
     description: See a user''s history
+    permission: ab.history
   warns:
     description: See your or a user''s warns
+    permission: ab.warns.own
   check:
     description: Get all information about a user
+    permission: ab.check
   systemPrefs:
     description: Displays System-Preferences for setting up the plugin
+    permission: ab.systemprefs
   unwarn:
     description: Deletes a warn
+    permission: ab.warn.undo
   unpunish:
     description: Deletes a punishment by ID
+    permission: ab.undo.all
   unban:
     description: Unban a user
+    permission: ab.undo.undo
   unmute:
     description: Unmute a user
+    permission: ab.warn.all
   change-reason:
     description: Change the reason of an existing punishment
+    permission: ab.changeReason


### PR DESCRIPTION
So the /help command isn't cluttered with commands players don't have permissions to use them