### PR TITLE
Added 2 API methods to UUIDManager

### DIFF
--- a/src/main/java/me/leoko/advancedban/manager/UUIDManager.java
+++ b/src/main/java/me/leoko/advancedban/manager/UUIDManager.java
@@ -136,6 +136,22 @@ public class UUIDManager {
     }
 
     /**
+     * Gets a name from a uuid only if AdvancedBan
+     * already has the uuid/name mapping in memory.
+     * 
+     * @param uuid the uuid without hyphens
+     * @return the player name or null if not found
+     */
+    public String getInMemoryName(String uuid) {
+        for (Entry<String, String> rs : activeUUIDs.entrySet()) {
+            if (rs.getValue().equalsIgnoreCase(uuid)) {
+                return rs.getKey();
+            }
+        }
+        return null;
+    }
+
+    /**
      * Get name from an uuid.
      *
      * @param uuid         the uuid

--- a/src/main/java/me/leoko/advancedban/manager/UUIDManager.java
+++ b/src/main/java/me/leoko/advancedban/manager/UUIDManager.java
@@ -118,10 +118,8 @@ public class UUIDManager {
      * @return the uuid
      */
     public String getUUID(String name) {
-        if (activeUUIDs.containsKey(name)) {
-            return activeUUIDs.get(name);
-        }
-        return getInitialUUID(name);
+        String inMemoryUuid = getInMemoryUUID(name);
+        return (inMemoryUuid != null) ? inMemoryUuid : getInitialUUID(name);
     }
 
     /**
@@ -169,11 +167,10 @@ public class UUIDManager {
         }
 
         if (!forceInitial) {
-            for (Entry<String, String> rs : activeUUIDs.entrySet()) {
-                if (rs.getValue().equalsIgnoreCase(uuid)) {
-                    return rs.getKey();
-                }
-            }
+        	String inMemoryName = getInMemoryName(uuid);
+        	if (inMemoryName != null) {
+        		return inMemoryName;
+        	}
         }
 
         try (Scanner scanner = new Scanner(new URL("https://api.mojang.com/user/profiles/" + uuid + "/names").openStream(), "UTF-8")) {

--- a/src/main/java/me/leoko/advancedban/manager/UUIDManager.java
+++ b/src/main/java/me/leoko/advancedban/manager/UUIDManager.java
@@ -125,6 +125,17 @@ public class UUIDManager {
     }
 
     /**
+     * Gets a uuid from a name only if AdvancedBan
+     * already has the uuid/name mapping in memory.
+     * 
+     * @param name the player name
+     * @return the nonhyphenated uuid or null if not found
+     */
+    public String getInMemoryUUID(String name) {
+    	return activeUUIDs.get(name);
+    }
+
+    /**
      * Get name from an uuid.
      *
      * @param uuid         the uuid


### PR DESCRIPTION
These simple methods allow programmers to get a UUID from a player name, or vice-versa, provided AdvancedBan already stores the uuid/name mapping in memory. While I will be using these methods for my project [UUIDVault](https://github.com/A248/UUIDVault), they will be generally useful nonetheless.

Furthermore, these methods have very little associated contract. Should AdvancedBan ever decide to change the internal implementation of UUIDManager, such as by removing `activeUUIDs`, then these methods would simply be deprecated and return null.