### PR TITLE
Relocate dependencies using maven-shade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,8 +119,9 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <version>1.7.30</version>
-            <scope>compile</scope>
+            <!-- Should be the same version as HikariCP uses -->
+            <version>1.7.25</version>
+            <scope>runtime</scope>
         </dependency>
     </dependencies>
     <build>
@@ -142,16 +143,25 @@
                 <version>3.2.0</version>
                 <configuration>
                     <relocations>
+                    	<relocation>
+                    		<pattern>org.apache.commons</pattern>
+                    		<shadedPattern>${project.groupId}.shaded.org.apache.commons</shadedPattern>
+                    	</relocation>
+                    	<relocation>
+                    		<pattern>org.slf4j</pattern>
+                    		<shadedPattern>${project.groupId}.shaded.org.slf4j</shadedPattern>
+                    	</relocation>
+                    	<relocation>
+                    		<pattern>com.zaxxer.hikari</pattern>
+                    		<shadedPattern>${project.groupId}.shaded.com.zaxxer.hikari</shadedPattern>
+                    	</relocation>
+                    	<relocation>
+                    		<pattern>org.hsqldb</pattern>
+                    		<shadedPattern>${project.groupId}.shaded.org.hsqldb</shadedPattern>
+                    	</relocation>
                         <relocation>
                             <pattern>org.bstats</pattern>
-                            <shadedPattern>${project.groupId}</shadedPattern>
-                            <excludes>
-                                <exclude>org.bstats.bungeecord.*</exclude>
-                            </excludes>
-                        </relocation>
-                        <relocation>
-                            <pattern>org.bstats.bungeecord</pattern>
-                            <shadedPattern>${project.groupId}.bungee</shadedPattern>
+                            <shadedPattern>${project.groupId}.shaded.org.bstats</shadedPattern>
                         </relocation>
                     </relocations>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.0</version>
+                <version>3.2.3</version>
                 <configuration>
                     <relocations>
                     	<relocation>
@@ -164,6 +164,9 @@
                             <shadedPattern>${project.groupId}.shaded.org.bstats</shadedPattern>
                         </relocation>
                     </relocations>
+                    <transformers>
+                        <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                    </transformers>
                 </configuration>
                 <executions>
                     <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
+            <artifactId>slf4j-jdk14</artifactId>
             <!-- Should be the same version as HikariCP uses -->
             <version>1.7.25</version>
             <scope>runtime</scope>

--- a/src/main/java/me/leoko/advancedban/utils/DynamicDataSource.java
+++ b/src/main/java/me/leoko/advancedban/utils/DynamicDataSource.java
@@ -22,8 +22,8 @@ public class DynamicDataSource {
             config.setUsername(usrName);
             config.setPassword(password);
         } else {
-        	// No need to worry about relocation because the maven-shade-plugin also changes strings
-        	String driverClassName = "org.hsqldb.jdbc.JDBCDriver";
+            // No need to worry about relocation because the maven-shade-plugin also changes strings
+            String driverClassName = "org.hsqldb.jdbc.JDBCDriver";
             Class.forName(driverClassName);
             config.setDriverClassName(driverClassName);
             config.setJdbcUrl("jdbc:hsqldb:file:" + mi.getDataFolder().getPath() + "/data/storage;hsqldb.lock_file=false");

--- a/src/main/java/me/leoko/advancedban/utils/DynamicDataSource.java
+++ b/src/main/java/me/leoko/advancedban/utils/DynamicDataSource.java
@@ -22,7 +22,10 @@ public class DynamicDataSource {
             config.setUsername(usrName);
             config.setPassword(password);
         } else {
-            Class.forName("org.hsqldb.jdbc.JDBCDriver");
+        	// No need to worry about relocation because the maven-shade-plugin also changes strings
+        	String driverClassName = "org.hsqldb.jdbc.JDBCDriver";
+            Class.forName(driverClassName);
+            config.setDriverClassName(driverClassName);
             config.setJdbcUrl("jdbc:hsqldb:file:" + mi.getDataFolder().getPath() + "/data/storage;hsqldb.lock_file=false");
             config.setUsername("SA");
             config.setPassword("");


### PR DESCRIPTION
This PR is to solve #351 by relocating AdvancedBan's shaded dependencies to *me.leoko.advancedban.shaded.**

There's still 1 issue, which, although minor, I would prefer to solve.

~~**This is still in progress** for 2 reasons, which, although they are minor, I would prefer to solve.~~

### ~~Log Messages~~

~~For one, I haven't found a way to shorten these log messages, nor to get them to log at the correct level.~~

~~It is possible to use a log4j2.xml file and direct the server instance to use it. However, doing so only changes the output of the message before the ':', after which the message is determined by slf4j-simple and is thus constant.~~

### HSQLDB as a registered Driver

For two, other plugins still use AdvancedBan's hsqldb, even though it is relocated. I luckily realised this because I accidentally left AntiVPN on the test server, which uses sqlite.
```
[13:57:25 INFO]: [com.zaxxer.hikari.HikariDataSource] AntiVPN-SQLite - Starting...
[13:57:25 WARN]: [AntiVPN] Loaded class me.leoko.advancedban.shaded.org.hsqldb.jdbc.JDBCDriver from AdvancedBan v2.1.9 which is not a depend, softdepend or loadbefore of this plugin.
[13:57:25 INFO]: [com.zaxxer.hikari.HikariDataSource] AntiVPN-SQLite - Start completed.
```
At the very least, AntiVPN *is* using its own HikariCP. This is an improvement over #351 . 
However, HikariCP detects and uses AdvancedBan's relocated hsqldb. I am not sure if this a feature or a bug; it may be that this is the intended behavior of AntiVPN/HikariCP with sqlite/hsqldb.

I will link an [AntiVPN](https://github.com/egg82/AntiVPN) issue to this one in case its developer may know any way to solve this.