### PR TITLE
Fixes UUID Cache not working for multi-case names

### DIFF
--- a/src/main/java/me/leoko/advancedban/manager/UUIDManager.java
+++ b/src/main/java/me/leoko/advancedban/manager/UUIDManager.java
@@ -107,7 +107,7 @@ public class UUIDManager {
      */
     public void supplyInternUUID(String name, UUID uuid) {
         if (mode == FetcherMode.INTERN || mode == FetcherMode.MIXED) {
-            activeUUIDs.put(name, uuid.toString().replace("-", ""));
+            activeUUIDs.put(name.toLowerCase(), uuid.toString().replace("-", ""));
         }
     }
 

--- a/src/main/java/me/leoko/advancedban/manager/UUIDManager.java
+++ b/src/main/java/me/leoko/advancedban/manager/UUIDManager.java
@@ -145,7 +145,7 @@ public class UUIDManager {
      * @return the nonhyphenated uuid or null if not found
      */
     public String getInMemoryUUID(String name) {
-        return activeUUIDs.get(name);
+        return activeUUIDs.get(name.toLowerCase());
     }
 
     /**
@@ -200,6 +200,7 @@ public class UUIDManager {
 
 
     private String askAPI(String url, String name, String key) throws IOException {
+        name = name.toLowerCase();
         HttpURLConnection request = (HttpURLConnection) new URL(url.replaceAll("%NAME%", name).replaceAll("%TIMESTAMP%", new Date().getTime() + "")).openConnection();
         request.connect();
 


### PR DESCRIPTION
if a player had multiple cases in their name the uuid cache would fail to work,

![image](https://user-images.githubusercontent.com/20372645/83252175-b152f800-a1a2-11ea-9b42-18c0eb97b45e.png)

This fixes #317 