### PR TITLE
Ensure AdvancedBan does not change foreign commands

### DIFF
--- a/src/main/java/me/leoko/advancedban/bukkit/BukkitMethods.java
+++ b/src/main/java/me/leoko/advancedban/bukkit/BukkitMethods.java
@@ -145,7 +145,7 @@ public class BukkitMethods implements MethodInterface {
 
     @Override
     public void setCommandExecutor(String cmd) {
-        PluginCommand command = Bukkit.getPluginCommand(cmd);
+        PluginCommand command = getPlugin().getCommand(cmd);
         if (command != null) {
             command.setExecutor(CommandReceiver.get());
         } else {

--- a/src/main/java/me/leoko/advancedban/bukkit/BukkitMethods.java
+++ b/src/main/java/me/leoko/advancedban/bukkit/BukkitMethods.java
@@ -145,7 +145,8 @@ public class BukkitMethods implements MethodInterface {
 
     @Override
     public void setCommandExecutor(String cmd) {
-        PluginCommand command = getPlugin().getCommand(cmd);
+        boolean friendly = getBoolean(getConfig(), "Friendly Register Commands", false);
+        PluginCommand command = (friendly) ? getPlugin().getCommand(cmd) : Bukkit.getPluginCommand(cmd);
         if (command != null) {
             command.setExecutor(CommandReceiver.get());
         } else {

--- a/src/main/java/me/leoko/advancedban/manager/UpdateManager.java
+++ b/src/main/java/me/leoko/advancedban/manager/UpdateManager.java
@@ -167,6 +167,13 @@ public class UpdateManager {
                         "Disable Prefix: false"
                 ));
             }
+            if (!mi.contains(mi.getConfig(), "Friendly Register Commands")) {
+                lines.addAll(Arrays.asList("",
+                        "# Register commands in a more friendly manner",
+                        "# Off by default, so AdvancedBan can override /ban from other plugins",
+                        "# This is a Bukkit-specific option. It has no meaning on BungeeCord",
+                        "Friendly Register Commands: false"));
+            }
             FileUtils.writeLines(file, lines);
         } catch (IOException exc) {
             exc.printStackTrace();

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -131,3 +131,8 @@ Log Purge Days: 10
 
 # Removes the prefix of the plugin in every message.
 Disable Prefix: false
+
+# Register commands in a more friendly manner
+# Off by default, so AdvancedBan can override /ban from other plugins
+# This is a Bukkit-specific option. It has no meaning on BungeeCord
+Friendly Register Commands: false


### PR DESCRIPTION
AdvancedBan currently uses `Server#getPluginCommand`, which can return any PluginCommand, not just those belonging to the calling plugin. The effect of this is that AB accidentally sets the executor of other plugins' commands, supposing they define commands with the same name as those by AB.

### Example - Insights Plugin

Before:
* `/check` uses AB's /check
* `/insights:check` uses AdvancedBan's /check
* `/advancedban:check` reports blank output (This happens because the CommandExecutor is set to the JavaPlugin by default)
After:
* `/check` uses Insights's /check
* `/insights:check` uses Insight's /check
* `/advancedban:check` uses AB's /check

Ref: https://www.spigotmc.org/resources/insights-super-configurable-limits-a-sync-scans-realtime-1-8-1-16-1.56489/

### Solution

Use JavaPlugin#getCommand, which will use the correct command if multiple plugins define the same command.