### PR TITLE
Database queries need not block each other

### DIFF
--- a/core/src/main/java/me/leoko/advancedban/manager/DatabaseManager.java
+++ b/core/src/main/java/me/leoko/advancedban/manager/DatabaseManager.java
@@ -107,7 +107,7 @@ public class DatabaseManager {
         return executeStatement(sql.toString(), result, parameters);
     }
 
-    private synchronized ResultSet executeStatement(String sql, boolean result, Object... parameters) {
+    private ResultSet executeStatement(String sql, boolean result, Object... parameters) {
     	try (Connection connection = dataSource.getConnection(); PreparedStatement statement = connection.prepareStatement(sql)) {
 
     		for (int i = 0; i < parameters.length; i++) {


### PR DESCRIPTION
This small change means AdvancedBan can actually execute database queries concurrently, truly fulfilling the use of HikariCP.