### PR TITLE
Patch up initialisation of singleton managers

### DIFF
--- a/core/src/main/java/me/leoko/advancedban/manager/CommandManager.java
+++ b/core/src/main/java/me/leoko/advancedban/manager/CommandManager.java
@@ -15,7 +15,7 @@ public class CommandManager {
      *
      * @return the command manager instance
      */
-    public static CommandManager get() {
+    public static synchronized CommandManager get() {
         return instance == null ? instance = new CommandManager() : instance;
     }
 

--- a/core/src/main/java/me/leoko/advancedban/manager/DatabaseManager.java
+++ b/core/src/main/java/me/leoko/advancedban/manager/DatabaseManager.java
@@ -35,7 +35,7 @@ public class DatabaseManager {
      *
      * @return the database manager instance
      */
-    public static DatabaseManager get() {
+    public static synchronized DatabaseManager get() {
         return instance == null ? instance = new DatabaseManager() : instance;
     }
 

--- a/core/src/main/java/me/leoko/advancedban/manager/MessageManager.java
+++ b/core/src/main/java/me/leoko/advancedban/manager/MessageManager.java
@@ -13,7 +13,9 @@ import java.util.List;
  */
 public class MessageManager {
 
-    private static final MethodInterface mi = Universal.get().getMethods();
+    private static MethodInterface mi() {
+    	return Universal.get().getMethods();
+    }
 
     /**
      * Get the message from the given path.<br>
@@ -24,6 +26,7 @@ public class MessageManager {
      * @return the message
      */
     public static String getMessage(String path, String... parameters) {
+    	MethodInterface mi = mi();
         String str = mi.getString(mi.getMessages(), path);
         if (str == null) {
             str = "Failed! See console for details!";
@@ -49,6 +52,7 @@ public class MessageManager {
      * @return the message
      */
     public static String getMessage(String path, boolean prefix, String... parameters) {
+    	MethodInterface mi = mi();
         String prefixStr = "";
         if(prefix && !mi.getBoolean(mi.getConfig(), "Disable Prefix", false))
             prefixStr = getMessage("General.Prefix")+" ";
@@ -67,6 +71,7 @@ public class MessageManager {
      * @return the layout
      */
     public static List<String> getLayout(Object file, String path, String... parameters) {
+    	MethodInterface mi = mi();
         if (mi.contains(file, path)) {
             List<String> list = new ArrayList<>();
             for (String str : mi.getStringList(file, path)) {
@@ -74,10 +79,11 @@ public class MessageManager {
             }
             return list;
         }
-		System.out.println("!! Message-Error in " + mi.getFileName(file) + "!\n"
+        String fileName = mi.getFileName(file);
+		System.out.println("!! Message-Error in " + fileName + "!\n"
 		        + "In order to solve the problem please:"
-		        + "\n  - Check the " + mi.getFileName(file) + "-File for any missing or double \" or '"
-		        + "\n  - Visit yamllint.com to  validate your " + mi.getFileName(file)
+		        + "\n  - Check the " + fileName + "-File for any missing or double \" or '"
+		        + "\n  - Visit yamllint.com to  validate your " + fileName
 		        + "\n  - Delete the message file and restart the server");
 		return Collections.singletonList("Failed! See console for details!");
     }
@@ -97,6 +103,7 @@ public class MessageManager {
      * @param parameters the parameters
      */
     public static void sendMessage(Object receiver, String path, boolean prefix, String... parameters) {
+    	MethodInterface mi = mi();
         mi.sendMessage(receiver, (prefix && !mi.getBoolean(mi.getConfig(), "Disable Prefix", false) ? getMessage("General.Prefix") + " " : "") + getMessage(path, parameters));
     }
 

--- a/core/src/main/java/me/leoko/advancedban/manager/PunishmentManager.java
+++ b/core/src/main/java/me/leoko/advancedban/manager/PunishmentManager.java
@@ -17,17 +17,20 @@ import java.util.*;
 public class PunishmentManager {
 
     private static PunishmentManager instance = null;
-    private final Universal universal = Universal.get();
     private final Set<Punishment> punishments = Collections.synchronizedSet(new HashSet<>());
     private final Set<Punishment> history = Collections.synchronizedSet(new HashSet<>());
     private final Set<String> cached = Collections.synchronizedSet(new HashSet<>());
+    
+    private Universal universal() {
+    	return Universal.get();
+    }
 
     /**
      * Get the punishment manager.
      *
      * @return the punishment manager instance
      */
-    public static PunishmentManager get() {
+    public static synchronized PunishmentManager get() {
         return instance == null ? instance = new PunishmentManager() : instance;
     }
 
@@ -69,6 +72,7 @@ public class PunishmentManager {
             }
 
         } catch (SQLException ex) {
+        	Universal universal = universal();
             universal.log("An error has occurred loading the punishments from the database.");
             universal.debugSqlException(ex);
             return null;
@@ -139,6 +143,7 @@ public class PunishmentManager {
                     }
                 }
             } catch (SQLException ex) {
+            	Universal universal = universal();
                 universal.log("An error has occurred getting the punishments for " + target);
                 universal.debugSqlException(ex);
             }
@@ -165,6 +170,7 @@ public class PunishmentManager {
             }
             rs.close();
         } catch (SQLException ex) {
+        	Universal universal = universal();
             universal.log("An error has occurred executing a query in the database.");
             universal.debug("Query: \n" + sqlQuery);
             universal.debugSqlException(ex);
@@ -193,6 +199,7 @@ public class PunishmentManager {
                     return punishment;
             }
         } catch (SQLException ex) {
+        	Universal universal = universal();
             universal.log("An error has occurred getting a punishment by his id.");
             universal.debug("Punishment id: '" + id + "'");
             universal.debugSqlException(ex);
@@ -334,6 +341,7 @@ public class PunishmentManager {
             }
 
         } catch (SQLException ex) {
+        	Universal universal = universal();
             universal.log("An error has occurred getting the level for the layout '" + layout + "' for '" + uuid + "'");
             universal.debugSqlException(ex);
         }

--- a/core/src/main/java/me/leoko/advancedban/manager/UUIDManager.java
+++ b/core/src/main/java/me/leoko/advancedban/manager/UUIDManager.java
@@ -17,14 +17,17 @@ public class UUIDManager {
     private static UUIDManager instance = null;
     private FetcherMode mode;
     private final Map<String, String> activeUUIDs = new HashMap<>();
-    private final MethodInterface mi = Universal.get().getMethods();
+    
+    private MethodInterface mi() {
+    	return Universal.get().getMethods();
+    }
 
     /**
      * Get the uuid manager.
      *
      * @return the uuid manager instance
      */
-    public static UUIDManager get() {
+    public static synchronized UUIDManager get() {
         return instance == null ? instance = new UUIDManager() : instance;
     }
 
@@ -33,6 +36,7 @@ public class UUIDManager {
      * based on the configured preference and the servers capabilities.
      */
     public void setup() {
+    	MethodInterface mi = mi();
         if (mi.getBoolean(mi.getConfig(), "UUID-Fetcher.Dynamic", true)) {
             if (!mi.isOnlineMode()) {
                 mode = FetcherMode.DISABLED;
@@ -62,6 +66,7 @@ public class UUIDManager {
      * @return the uuid
      */
     public String getInitialUUID(String name) {
+    	MethodInterface mi = mi();
         name = name.toLowerCase();
         if (mode == FetcherMode.DISABLED)
             return name;
@@ -172,6 +177,7 @@ public class UUIDManager {
      * @return the name from uuid
      */
     public String getNameFromUUID(String uuid, boolean forceInitial) {
+    	MethodInterface mi = mi();
         if (mode == FetcherMode.DISABLED)
             return uuid;
 
@@ -200,6 +206,7 @@ public class UUIDManager {
 
 
     private String askAPI(String url, String name, String key) throws IOException {
+    	MethodInterface mi = mi();
         name = name.toLowerCase();
         HttpURLConnection request = (HttpURLConnection) new URL(url.replaceAll("%NAME%", name).replaceAll("%TIMESTAMP%", new Date().getTime() + "")).openConnection();
         request.connect();

--- a/core/src/main/java/me/leoko/advancedban/manager/UpdateManager.java
+++ b/core/src/main/java/me/leoko/advancedban/manager/UpdateManager.java
@@ -23,7 +23,7 @@ public class UpdateManager {
      *
      * @return the update manager instance
      */
-    public static UpdateManager get() {
+    public static synchronized UpdateManager get() {
         return instance == null ? instance = new UpdateManager() : instance;
     }
 


### PR DESCRIPTION
This should improve the general resilience of AdvancedBan to plugins doing all sorts of things, including possibly forcing the initialisation of AdvancedBan's singletons. Should fix #406 

Also, I added the `synchronized` keyword to the get() methods. Although it is incredibly rare that 2 instances would be created, it is better to take this minor precaution than let some user somewhere suffer an obscure bug, only to find that it disappears when the user restarts the server.

