### PR TITLE
Refactor and consolidate configuration file loading

### DIFF
--- a/bukkit/src/main/java/me/leoko/advancedban/bukkit/BukkitMethods.java
+++ b/bukkit/src/main/java/me/leoko/advancedban/bukkit/BukkitMethods.java
@@ -1,6 +1,6 @@
 package me.leoko.advancedban.bukkit;
 
-import me.leoko.advancedban.MethodInterface;
+import me.leoko.advancedban.AbstractMethodInterface;
 import me.leoko.advancedban.Universal;
 import me.leoko.advancedban.bukkit.event.PunishmentEvent;
 import me.leoko.advancedban.bukkit.event.RevokePunishmentEvent;
@@ -17,6 +17,7 @@ import org.bukkit.ChatColor;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.PluginCommand;
+import org.bukkit.configuration.InvalidConfigurationException;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.RegisteredServiceProvider;
@@ -25,10 +26,15 @@ import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
 
-import java.io.*;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
@@ -37,19 +43,12 @@ import java.util.function.BiFunction;
 /**
  * Created by Leoko @ dev.skamps.eu on 23.07.2016.
  */
-public class BukkitMethods implements MethodInterface {
+public class BukkitMethods extends AbstractMethodInterface<YamlConfiguration> {
 
-    private final File messageFile = new File(getDataFolder(), "Messages.yml");
-    private final File layoutFile = new File(getDataFolder(), "Layouts.yml");
-    private final File mysqlFile = new File(getDataFolder(), "MySQL.yml");
-    private YamlConfiguration config;
-    private File configFile = new File(getDataFolder(), "config.yml");
-    private YamlConfiguration messages;
-    private YamlConfiguration layouts;
-    private YamlConfiguration mysql;
     private BiFunction<OfflinePlayer, String, Boolean> permissionVault;
 
     public BukkitMethods() {
+    	super(BukkitMain.get().getDataFolder().toPath());
         // Vault support
         if (Bukkit.getServer().getPluginManager().getPlugin("Vault") != null) {
             RegisteredServiceProvider<net.milkbowl.vault.permission.Permission> rsp = Bukkit.getServer().getServicesManager().getRegistration(net.milkbowl.vault.permission.Permission.class);
@@ -58,32 +57,18 @@ public class BukkitMethods implements MethodInterface {
     }
 
     @Override
-    public void loadFiles() {
-        if (!configFile.exists()) {
-            getPlugin().saveResource("config.yml", true);
-        }
-        if (!messageFile.exists()) {
-            getPlugin().saveResource("Messages.yml", true);
-        }
-        if (!layoutFile.exists()) {
-            getPlugin().saveResource("Layouts.yml", true);
-        }
+	protected YamlConfiguration loadConfiguration(Path path) throws IOException {
+		try (BufferedReader reader = Files.newBufferedReader(path, StandardCharsets.UTF_8)) {
 
-        try {
-            config = YamlConfiguration.loadConfiguration(new InputStreamReader(new FileInputStream(configFile), StandardCharsets.UTF_8));
-            messages = YamlConfiguration.loadConfiguration(new InputStreamReader(new FileInputStream(messageFile), StandardCharsets.UTF_8));
-            layouts = YamlConfiguration.loadConfiguration(new InputStreamReader(new FileInputStream(layoutFile), StandardCharsets.UTF_8));
+			YamlConfiguration config = new YamlConfiguration();
+			config.load(reader);
+			return config;
 
-            if (mysqlFile.exists()) {
-                mysql = YamlConfiguration.loadConfiguration(new InputStreamReader(new FileInputStream(mysqlFile), StandardCharsets.UTF_8));
-            } else {
-                mysql = YamlConfiguration.loadConfiguration(new InputStreamReader(new FileInputStream(configFile), StandardCharsets.UTF_8));
-            }
-        } catch (FileNotFoundException exc) {
-            // We just saved the files, so that should really not happen.
-            Universal.get().debugException(exc);
-        }
-    }
+		} catch (InvalidConfigurationException ex) {
+			throw new IllegalStateException(
+					"Unable to load configuration file " + path + ". Please check the file for YAML syntax errors", ex);
+		}
+	}
 
     @Override
     public String getFromUrlJson(String url, String key) {
@@ -113,21 +98,6 @@ public class BukkitMethods implements MethodInterface {
     @Override
     public String[] getKeys(Object file, String path) {
         return ((YamlConfiguration) file).getConfigurationSection(path).getKeys(false).toArray(new String[0]);
-    }
-
-    @Override
-    public YamlConfiguration getConfig() {
-        return config;
-    }
-
-    @Override
-    public YamlConfiguration getMessages() {
-        return messages;
-    }
-
-    @Override
-    public YamlConfiguration getLayouts() {
-        return layouts;
     }
 
     @Override
@@ -284,11 +254,6 @@ public class BukkitMethods implements MethodInterface {
             return true;
         }
         return false;
-    }
-
-    @Override
-    public YamlConfiguration getMySQLFile() {
-        return mysql;
     }
 
     @Override

--- a/core/src/main/java/me/leoko/advancedban/AbstractMethodInterface.java
+++ b/core/src/main/java/me/leoko/advancedban/AbstractMethodInterface.java
@@ -1,0 +1,94 @@
+package me.leoko.advancedban;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.EnumMap;
+import java.util.Map;
+
+public abstract class AbstractMethodInterface<C> implements MethodInterface {
+
+	private final Path dataFolder;
+	private final Map<ConfigType, C> configs = new EnumMap<>(ConfigType.class);
+
+	protected AbstractMethodInterface(Path dataFolder) {
+		this.dataFolder = dataFolder;
+	}
+
+	@Override
+	public final void loadFiles() {
+		try {
+			Files.createDirectories(dataFolder);
+
+			// Copy defaults if files do not exist
+			for (ConfigType config : ConfigType.values()) {
+				copyDefaultResourceIfNecessary(config);
+			}
+			// Load configurations
+			for (ConfigType config : ConfigType.values()) {
+				Path configPath = getPath(config);
+				if (config == ConfigType.MYSQL && !Files.exists(configPath)) {
+					configPath = getPath(ConfigType.CONFIG);
+				}
+				configs.put(config, loadConfiguration(configPath));
+			}
+		} catch (IOException ex) {
+			throw new UncheckedIOException(ex);
+		}
+	}
+
+	private void copyDefaultResourceIfNecessary(ConfigType config) throws IOException {
+		Path configPath = getPath(config);
+		if (config != ConfigType.MYSQL && !Files.exists(configPath)) {
+			try (InputStream inputStream = getClass().getResource("/" + config.fileName).openStream()) {
+				Files.copy(inputStream, configPath);
+			}
+		}
+	}
+
+	protected abstract C loadConfiguration(Path configPath) throws IOException;
+
+	private Path getPath(ConfigType config) {
+		return dataFolder.resolve(config.fileName);
+	}
+
+	protected enum ConfigType {
+		CONFIG("config.yml"), MESSAGES("Messages.yml"), LAYOUTS("Layouts.yml"),
+		/**
+		 * The MySQL.yml file is only maintained for legacy support. If it does not
+		 * exist, {@link CONFIG} is used
+		 * 
+		 */
+		MYSQL("MySQL.yml");
+
+		final String fileName;
+
+		private ConfigType(String fileName) {
+			this.fileName = fileName;
+		}
+
+	}
+
+	@Override
+	public final C getConfig() {
+		return configs.get(ConfigType.CONFIG);
+	}
+
+	@Override
+	public final C getMessages() {
+		return configs.get(ConfigType.MESSAGES);
+	}
+
+	@Override
+	public final C getLayouts() {
+		return configs.get(ConfigType.LAYOUTS);
+	}
+
+	@Override
+	public final C getMySQLFile() {
+		return configs.get(ConfigType.MYSQL);
+	}
+
+}


### PR DESCRIPTION
This started as a way to make support easier by making configuration loading fail-fast, but I realized there was a lot of duplicate code which could be reduced so did that as well.

This PR has no functional changes except by making the configuration loading fail-fast.

AdvancedBan used to load configurations using YamlConfiguration.load, but this static method is pretty poorly designed. Its fail-safe behaviour returns an empty (or partially complete?) YamlConfiguration instance. Since various parts of AdvancedBan assume configuration sections to exist, this causes NPEs to be thrown:

https://paste.hopefuls.de/bunicijuvu.bash
https://pastebin.com/cv40pGJw

With these changes, the user will be notified immediately of the problem, rather than having AdvancedBan continue on in a zombified state throwing intermittent NPEs.