### PR TITLE
Add setDriverClassName for hsqldb

### DIFF
--- a/core/src/main/java/me/leoko/advancedban/utils/DynamicDataSource.java
+++ b/core/src/main/java/me/leoko/advancedban/utils/DynamicDataSource.java
@@ -25,6 +25,7 @@ public class DynamicDataSource {
             config.setJdbcUrl("jdbc:hsqldb:file:" + mi.getDataFolder().getPath() + "/data/storage;hsqldb.lock_file=false");
             config.setUsername("SA");
             config.setPassword("");
+            config.setDriverClassName("org.hsqldb.jdbc.JDBCDriver");
         }
     }
 


### PR DESCRIPTION
Fixes a bug introduced in #438 , which causes a "No suitable driver" exception.

https://pastebin.com/q6Li9JNF

The fix is very simple. 