### PR TITLE
Ensure the ChatListenerVelocity recieves the event early

### DIFF
--- a/velocity/src/main/java/me/leoko/advancedban/velocity/listener/ChatListenerVelocity.java
+++ b/velocity/src/main/java/me/leoko/advancedban/velocity/listener/ChatListenerVelocity.java
@@ -1,12 +1,13 @@
 package me.leoko.advancedban.velocity.listener;
 
+import com.velocitypowered.api.event.PostOrder;
 import com.velocitypowered.api.event.Subscribe;
 import com.velocitypowered.api.event.player.PlayerChatEvent;
 import me.leoko.advancedban.Universal;
 
 public class ChatListenerVelocity {
 
-  @Subscribe
+  @Subscribe(order = PostOrder.FIRST)
   public void onChat(PlayerChatEvent event) {
     if (!event.getMessage().startsWith("/")) {
       if (Universal.get().getMethods().callChat(event.getPlayer())) {


### PR DESCRIPTION
This PR aims to make sure that the ChatListener on Velocity is called before other plugins, allowing them to easily check if the event is cancelled.