### PR TITLE
Register commands with permissions on Bungeecord

### DIFF
--- a/bungee/src/main/java/me/leoko/advancedban/bungee/BungeeMethods.java
+++ b/bungee/src/main/java/me/leoko/advancedban/bungee/BungeeMethods.java
@@ -14,6 +14,7 @@ import me.leoko.advancedban.bungee.utils.LuckPermsOfflineUser;
 import me.leoko.advancedban.manager.DatabaseManager;
 import me.leoko.advancedban.manager.PunishmentManager;
 import me.leoko.advancedban.manager.UUIDManager;
+import me.leoko.advancedban.utils.Command;
 import me.leoko.advancedban.utils.Permissionable;
 import me.leoko.advancedban.utils.Punishment;
 import me.leoko.advancedban.utils.tabcompletion.TabCompleter;
@@ -171,7 +172,7 @@ public class BungeeMethods implements MethodInterface {
 
     @Override
     public void setCommandExecutor(String cmd, TabCompleter tabCompleter) {
-        ProxyServer.getInstance().getPluginManager().registerCommand(getPlugin(), new CommandReceiverBungee(cmd));
+        ProxyServer.getInstance().getPluginManager().registerCommand(getPlugin(), new CommandReceiverBungee(cmd, Command.getByName(cmd).getPermission()));
     }
 
     @SuppressWarnings("deprecation")

--- a/bungee/src/main/java/me/leoko/advancedban/bungee/listener/CommandReceiverBungee.java
+++ b/bungee/src/main/java/me/leoko/advancedban/bungee/listener/CommandReceiverBungee.java
@@ -11,8 +11,8 @@ import net.md_5.bungee.api.plugin.Command;
 
 public class CommandReceiverBungee extends Command {
 
-    public CommandReceiverBungee(String name) {
-        super(name);
+    public CommandReceiverBungee(String name, String permission) {
+        super(name, permission);
     }
     
     @Override


### PR DESCRIPTION
This allows for not showing commands that the user can't execute in the autocompletion. Fixes #440