### PR TITLE
Tab-Completion and Layout Configuration Options

### DIFF
--- a/bukkit/pom.xml
+++ b/bukkit/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>me.leoko.advancedban</groupId>
         <artifactId>AdvancedBan</artifactId>
-        <version>2.4.0</version>
+        <version>2.4.1</version>
     </parent>
 
     <artifactId>AdvancedBan-Bukkit</artifactId>

--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>me.leoko.advancedban</groupId>
         <artifactId>AdvancedBan</artifactId>
-        <version>2.4.0</version>
+        <version>2.4.1</version>
     </parent>
 
     <artifactId>AdvancedBan-Bundle</artifactId>

--- a/bungee/pom.xml
+++ b/bungee/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>me.leoko.advancedban</groupId>
         <artifactId>AdvancedBan</artifactId>
-        <version>2.4.0</version>
+        <version>2.4.1</version>
     </parent>
 
     <artifactId>AdvancedBan-Bungee</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>me.leoko.advancedban</groupId>
         <artifactId>AdvancedBan</artifactId>
-        <version>2.4.0</version>
+        <version>2.4.1</version>
     </parent>
 
     <artifactId>AdvancedBan-Core</artifactId>

--- a/core/src/main/java/me/leoko/advancedban/utils/Command.java
+++ b/core/src/main/java/me/leoko/advancedban/utils/Command.java
@@ -559,18 +559,9 @@ public enum Command {
 
     public TabCompleter getTabCompleter() {
         MethodInterface mi = Universal.get().getMethods();
-        if (!mi.getBoolean(mi.getConfig(), "Use Tab Completion", true)) {
+        if (!mi.getBoolean(mi.getConfig(), "Use Tab Completion", true)) 
             return new NullTabCompleter();
-                @Override
-                public List<String> onTabComplete(Object user, String[] args) {
-                    // Return an empty arrayList in order to not suggest tab-completions
-                    return new ArrayList<>();
-                }
-            };
-
-        }
         return tabCompleter;
-
     }
 
     public static Command getByName(String name) {

--- a/core/src/main/java/me/leoko/advancedban/utils/Command.java
+++ b/core/src/main/java/me/leoko/advancedban/utils/Command.java
@@ -18,6 +18,7 @@ import me.leoko.advancedban.utils.tabcompletion.PunishmentTabCompleter;
 import me.leoko.advancedban.utils.tabcompletion.TabCompleter;
 import org.apache.commons.lang3.ArrayUtils;
 
+import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
 import java.util.List;
@@ -557,7 +558,19 @@ public enum Command {
 
 
     public TabCompleter getTabCompleter() {
+        MethodInterface mi = Universal.get().getMethods();
+        if (!mi.getBoolean(mi.getConfig(), "Use Tab Completion", true)) {
+            return new TabCompleter() {
+                @Override
+                public List<String> onTabComplete(Object user, String[] args) {
+                    // Return an empty arrayList in order to not suggest tab-completions
+                    return new ArrayList<>();
+                }
+            };
+
+        }
         return tabCompleter;
+
     }
 
     public static Command getByName(String name) {

--- a/core/src/main/java/me/leoko/advancedban/utils/Command.java
+++ b/core/src/main/java/me/leoko/advancedban/utils/Command.java
@@ -560,7 +560,7 @@ public enum Command {
     public TabCompleter getTabCompleter() {
         MethodInterface mi = Universal.get().getMethods();
         if (!mi.getBoolean(mi.getConfig(), "Use Tab Completion", true)) {
-            return new TabCompleter() {
+            return new NullTabCompleter();
                 @Override
                 public List<String> onTabComplete(Object user, String[] args) {
                     // Return an empty arrayList in order to not suggest tab-completions

--- a/core/src/main/java/me/leoko/advancedban/utils/Command.java
+++ b/core/src/main/java/me/leoko/advancedban/utils/Command.java
@@ -531,7 +531,7 @@ public enum Command {
     private final Consumer<CommandInput> commandHandler;
     private final String usagePath;
     private final String[] names;
-    private static final NullTabCompleter nullTabCompleter = new NullTabCompleter();
+    private static final NullTabCompleter NULL_TAB_COMPLETER  = new NullTabCompleter();
 
     Command(String permission, Predicate<String[]> syntaxValidator,
             TabCompleter tabCompleter, Consumer<CommandInput> commandHandler, String usagePath, String... names) {
@@ -561,7 +561,7 @@ public enum Command {
     public TabCompleter getTabCompleter() {
         MethodInterface mi = Universal.get().getMethods();
         if (!mi.getBoolean(mi.getConfig(), "Use Tab Completion", true)) 
-            return nullTabCompleter;
+            return NULL_TAB_COMPLETER;
         return tabCompleter;
     }
 

--- a/core/src/main/java/me/leoko/advancedban/utils/Command.java
+++ b/core/src/main/java/me/leoko/advancedban/utils/Command.java
@@ -531,6 +531,7 @@ public enum Command {
     private final Consumer<CommandInput> commandHandler;
     private final String usagePath;
     private final String[] names;
+    private static final NullTabCompleter nullTabCompleter = new NullTabCompleter();
 
     Command(String permission, Predicate<String[]> syntaxValidator,
             TabCompleter tabCompleter, Consumer<CommandInput> commandHandler, String usagePath, String... names) {
@@ -560,7 +561,7 @@ public enum Command {
     public TabCompleter getTabCompleter() {
         MethodInterface mi = Universal.get().getMethods();
         if (!mi.getBoolean(mi.getConfig(), "Use Tab Completion", true)) 
-            return new NullTabCompleter();
+            return nullTabCompleter;
         return tabCompleter;
     }
 

--- a/core/src/main/java/me/leoko/advancedban/utils/Command.java
+++ b/core/src/main/java/me/leoko/advancedban/utils/Command.java
@@ -18,7 +18,6 @@ import me.leoko.advancedban.utils.tabcompletion.PunishmentTabCompleter;
 import me.leoko.advancedban.utils.tabcompletion.TabCompleter;
 import org.apache.commons.lang3.ArrayUtils;
 
-import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
 import java.util.List;
@@ -134,9 +133,9 @@ public enum Command {
     UN_WARN("ab." + PunishmentType.WARNING.getName() + ".undo",
             "[0-9]+|(?i:clear \\S+)",
             new CleanTabCompleter((user, args) -> {
-                if (args.length == 1) {
+                if(args.length == 1) {
                     return list("[ID]", "clear");
-                } else if (args.length == 2 && args[0].equalsIgnoreCase("clear")) {
+                }else if(args.length == 2 && args[0].equalsIgnoreCase("clear")){
                     return list(CleanTabCompleter.PLAYER_PLACEHOLDER, "[Name]");
                 } else {
                     return list();
@@ -173,9 +172,9 @@ public enum Command {
     UN_NOTE("ab." + PunishmentType.NOTE.getName() + ".undo",
             "[0-9]+|(?i:clear \\S+)",
             new CleanTabCompleter((user, args) -> {
-                if (args.length == 1) {
+                if(args.length == 1) {
                     return list("[ID]", "clear");
-                } else if (args.length == 2 && args[0].equalsIgnoreCase("clear")) {
+                }else if(args.length == 2 && args[0].equalsIgnoreCase("clear")){
                     return list(CleanTabCompleter.PLAYER_PLACEHOLDER, "[Name]");
                 } else {
                     return list();
@@ -220,13 +219,13 @@ public enum Command {
     CHANGE_REASON("ab.changeReason",
             "([0-9]+|(?i)(ban|mute) \\S+) .+",
             new CleanTabCompleter((user, args) -> {
-                if (args.length <= 1) {
+                if(args.length <= 1) {
                     return list("<ID>", "ban", "mute");
-                } else {
+                }else {
                     boolean playerTarget = args[0].equalsIgnoreCase("ban") || args[0].equalsIgnoreCase("mute");
-                    if (args.length == 2 && playerTarget) {
+                    if(args.length == 2 && playerTarget){
                         return list(CleanTabCompleter.PLAYER_PLACEHOLDER, "[Name]");
-                    } else if ((playerTarget && args.length == 3) || args.length == 2) {
+                    } else if((playerTarget && args.length == 3) || args.length == 2){
                         return list("new reason...");
                     } else {
                         return list();
@@ -284,9 +283,9 @@ public enum Command {
     HISTORY("ab.history",
             "\\S+( [1-9][0-9]*)?",
             new CleanTabCompleter((user, args) -> {
-                if (args.length == 1)
+                if(args.length == 1)
                     return list(CleanTabCompleter.PLAYER_PLACEHOLDER, "[Name]");
-                else if (args.length == 2)
+                else if(args.length == 2)
                     return list("<Page>");
                 else
                     return list();
@@ -300,12 +299,12 @@ public enum Command {
     WARNS(null,
             "\\S+( [1-9][0-9]*)?|\\S+|",
             new CleanTabCompleter((user, args) -> {
-                if (args.length == 1)
-                    if (Universal.get().getMethods().hasPerms(user, "ab.notes.other"))
+                if(args.length == 1)
+                    if(Universal.get().getMethods().hasPerms(user, "ab.notes.other"))
                         return list(CleanTabCompleter.PLAYER_PLACEHOLDER, "<Name>", "<Page>");
                     else
                         return list("<Page>");
-                else if (args.length == 2 && !args[0].matches("\\d+"))
+                else if(args.length == 2 && !args[0].matches("\\d+"))
                     return list("<Page>");
                 else
                     return list();
@@ -327,7 +326,7 @@ public enum Command {
                     }
 
                     String name = Universal.get().getMethods().getName(input.getSender());
-                    String identifier = processName(new Command.CommandInput(input.getSender(), new String[] { name }));
+                    String identifier = processName(new Command.CommandInput(input.getSender(), new String[]{name}));
                     new ListProcessor(
                             target -> PunishmentManager.get().getPunishments(identifier, PunishmentType.WARNING, true),
                             "WarnsOwn", false, false).accept(input);
@@ -338,12 +337,12 @@ public enum Command {
     NOTES(null,
             "\\S+( [1-9][0-9]*)?|\\S+|",
             new CleanTabCompleter((user, args) -> {
-                if (args.length == 1)
-                    if (Universal.get().getMethods().hasPerms(user, "ab.notes.other"))
+                if(args.length == 1)
+                    if(Universal.get().getMethods().hasPerms(user, "ab.notes.other"))
                         return list(CleanTabCompleter.PLAYER_PLACEHOLDER, "<Name>", "<Page>");
                     else
                         return list("<Page>");
-                else if (args.length == 2 && !args[0].matches("\\d+"))
+                else if(args.length == 2 && !args[0].matches("\\d+"))
                     return list("<Page>");
                 else
                     return list();
@@ -365,7 +364,7 @@ public enum Command {
                     }
 
                     String name = Universal.get().getMethods().getName(input.getSender());
-                    String identifier = processName(new Command.CommandInput(input.getSender(), new String[] { name }));
+                    String identifier = processName(new Command.CommandInput(input.getSender(), new String[]{name}));
                     new ListProcessor(
                             target -> PunishmentManager.get().getPunishments(identifier, PunishmentType.NOTE, true),
                             "NotesOwn", false, false).accept(input);
@@ -397,30 +396,23 @@ public enum Command {
                 boolean uuidCached = PunishmentManager.get().isCached(uuid);
 
                 Object sender = input.getSender();
-                MessageManager.sendMessage(sender, "Check.Header", true, "NAME", name, "CACHED",
-                        nameCached ? cached : notCached);
-                MessageManager.sendMessage(sender, "Check.UUID", false, "UUID", uuid, "CACHED",
-                        uuidCached ? cached : notCached);
+                MessageManager.sendMessage(sender, "Check.Header", true, "NAME", name, "CACHED", nameCached ? cached : notCached);
+                MessageManager.sendMessage(sender, "Check.UUID", false, "UUID", uuid, "CACHED", uuidCached ? cached : notCached);
                 if (Universal.get().hasPerms(sender, "ab.check.ip")) {
-                    MessageManager.sendMessage(sender, "Check.IP", false, "IP", ip, "CACHED",
-                            ipCached ? cached : notCached);
+                    MessageManager.sendMessage(sender, "Check.IP", false, "IP", ip, "CACHED", ipCached ? cached : notCached);
                 }
                 MessageManager.sendMessage(sender, "Check.Geo", false, "LOCATION", loc == null ? "failed!" : loc);
-                MessageManager.sendMessage(sender, "Check.Mute", false, "DURATION",
-                        mute == null ? "§anone" : mute.getType().isTemp() ? "§e" + mute.getDuration(false) : "§cperma");
+                MessageManager.sendMessage(sender, "Check.Mute", false, "DURATION", mute == null ? "§anone" : mute.getType().isTemp() ? "§e" + mute.getDuration(false) : "§cperma");
                 if (mute != null) {
                     MessageManager.sendMessage(sender, "Check.MuteReason", false, "REASON", mute.getReason());
                 }
-                MessageManager.sendMessage(sender, "Check.Ban", false, "DURATION",
-                        ban == null ? "§anone" : ban.getType().isTemp() ? "§e" + ban.getDuration(false) : "§cperma");
+                MessageManager.sendMessage(sender, "Check.Ban", false, "DURATION", ban == null ? "§anone" : ban.getType().isTemp() ? "§e" + ban.getDuration(false) : "§cperma");
                 if (ban != null) {
                     MessageManager.sendMessage(sender, "Check.BanReason", false, "REASON", ban.getReason());
                 }
-                MessageManager.sendMessage(sender, "Check.Warn", false, "COUNT",
-                        PunishmentManager.get().getCurrentWarns(uuid) + "");
+                MessageManager.sendMessage(sender, "Check.Warn", false, "COUNT", PunishmentManager.get().getCurrentWarns(uuid) + "");
 
-                MessageManager.sendMessage(sender, "Check.Note", false, "COUNT",
-                        PunishmentManager.get().getCurrentNotes(uuid) + "");
+                MessageManager.sendMessage(sender, "Check.Note", false, "COUNT", PunishmentManager.get().getCurrentNotes(uuid) + "");
             },
             "Check.Usage",
             "check"),
@@ -433,14 +425,12 @@ public enum Command {
                 Calendar calendar = new GregorianCalendar();
                 Object sender = input.getSender();
                 mi.sendMessage(sender, "§c§lAdvancedBan v2 §cSystemPrefs");
-                mi.sendMessage(sender, "§cServer-Time §8» §7" + calendar.get(Calendar.HOUR_OF_DAY) + ":"
-                        + calendar.get(Calendar.MINUTE));
+                mi.sendMessage(sender, "§cServer-Time §8» §7" + calendar.get(Calendar.HOUR_OF_DAY) + ":" + calendar.get(Calendar.MINUTE));
                 mi.sendMessage(sender, "§cYour UUID (Intern) §8» §7" + mi.getInternUUID(sender));
                 if (input.hasNext()) {
                     String target = input.getPrimaryData();
                     mi.sendMessage(sender, "§c" + target + "'s UUID (Intern) §8» §7" + mi.getInternUUID(target));
-                    mi.sendMessage(sender,
-                            "§c" + target + "'s UUID (Fetched) §8» §7" + UUIDManager.get().getUUID(target));
+                    mi.sendMessage(sender, "§c" + target + "'s UUID (Fetched) §8» §7" + UUIDManager.get().getUUID(target));
                 }
             },
             null,
@@ -516,21 +506,19 @@ public enum Command {
                     }
                 }
 
+
                 mi.sendMessage(sender, "§8§l§m-=====§r §c§lAdvancedBan v2 §8§l§m=====-§r ");
                 mi.sendMessage(sender, "  §cDev §8• §7Leoko");
                 mi.sendMessage(sender, "  §cStatus §8• §a§oStable");
                 mi.sendMessage(sender, "  §cVersion §8• §7" + mi.getVersion());
                 mi.sendMessage(sender, "  §cLicense §8• §7Public");
-                mi.sendMessage(sender, "  §cStorage §8• §7"
-                        + (DatabaseManager.get().isUseMySQL() ? "MySQL (external)" : "HSQLDB (local)"));
+                mi.sendMessage(sender, "  §cStorage §8• §7" + (DatabaseManager.get().isUseMySQL() ? "MySQL (external)" : "HSQLDB (local)"));
                 mi.sendMessage(sender, "  §cServer §8• §7" + Universal.get().getServerType().toString());
                 if (Universal.get().isProxy() && Universal.get().getServerType() == ServerType.BUNGEECORD) {
                     mi.sendMessage(sender, "  §cRedisBungee §8• §7" + (Universal.isRedis() ? "true" : "false"));
                 }
                 mi.sendMessage(sender, "  §cUUID-Mode §8• §7" + UUIDManager.get().getMode());
-                mi.sendMessage(sender,
-                        "  §cPrefix §8• §7" + (mi.getBoolean(mi.getConfig(), "Disable Prefix", false) ? ""
-                                : MessageManager.getMessage("General.Prefix")));
+                mi.sendMessage(sender, "  §cPrefix §8• §7" + (mi.getBoolean(mi.getConfig(), "Disable Prefix", false) ? "" : MessageManager.getMessage("General.Prefix")));
                 mi.sendMessage(sender, "§8§l§m-=========================-§r ");
             },
             null,
@@ -555,8 +543,7 @@ public enum Command {
 
     Command(String permission, String regex, TabCompleter tabCompleter, Consumer<CommandInput> commandHandler,
             String usagePath, String... names) {
-        this(permission, (args) -> String.join(" ", args).matches(regex), tabCompleter, commandHandler, usagePath,
-                names);
+        this(permission, (args) -> String.join(" ", args).matches(regex), tabCompleter, commandHandler, usagePath, names);
     }
 
     public boolean validateArguments(String[] args) {
@@ -567,21 +554,9 @@ public enum Command {
         commandHandler.accept(new CommandInput(player, args));
     }
 
+
+
     public TabCompleter getTabCompleter() {
-
-        MethodInterface mi = Universal.get().getMethods();
-
-        if (!mi.getBoolean(mi.getConfig(), "Use Tab Completion", true)) {
-
-            // Return an empty Tab completer as the tab completion was disabled in the config
-            return new TabCompleter() {
-
-                @Override
-                public List<String> onTabComplete(Object user, String[] args) {
-                    return new ArrayList<>();
-                }
-            };
-        }
         return tabCompleter;
     }
 

--- a/core/src/main/java/me/leoko/advancedban/utils/Command.java
+++ b/core/src/main/java/me/leoko/advancedban/utils/Command.java
@@ -531,7 +531,7 @@ public enum Command {
     private final Consumer<CommandInput> commandHandler;
     private final String usagePath;
     private final String[] names;
-    private static final NullTabCompleter NULL_TAB_COMPLETER  = new NullTabCompleter();
+    private static final NullTabCompleter NULL_TAB_COMPLETER = new NullTabCompleter();
 
     Command(String permission, Predicate<String[]> syntaxValidator,
             TabCompleter tabCompleter, Consumer<CommandInput> commandHandler, String usagePath, String... names) {

--- a/core/src/main/java/me/leoko/advancedban/utils/Command.java
+++ b/core/src/main/java/me/leoko/advancedban/utils/Command.java
@@ -18,6 +18,7 @@ import me.leoko.advancedban.utils.tabcompletion.PunishmentTabCompleter;
 import me.leoko.advancedban.utils.tabcompletion.TabCompleter;
 import org.apache.commons.lang3.ArrayUtils;
 
+import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
 import java.util.List;
@@ -133,9 +134,9 @@ public enum Command {
     UN_WARN("ab." + PunishmentType.WARNING.getName() + ".undo",
             "[0-9]+|(?i:clear \\S+)",
             new CleanTabCompleter((user, args) -> {
-                if(args.length == 1) {
+                if (args.length == 1) {
                     return list("[ID]", "clear");
-                }else if(args.length == 2 && args[0].equalsIgnoreCase("clear")){
+                } else if (args.length == 2 && args[0].equalsIgnoreCase("clear")) {
                     return list(CleanTabCompleter.PLAYER_PLACEHOLDER, "[Name]");
                 } else {
                     return list();
@@ -172,9 +173,9 @@ public enum Command {
     UN_NOTE("ab." + PunishmentType.NOTE.getName() + ".undo",
             "[0-9]+|(?i:clear \\S+)",
             new CleanTabCompleter((user, args) -> {
-                if(args.length == 1) {
+                if (args.length == 1) {
                     return list("[ID]", "clear");
-                }else if(args.length == 2 && args[0].equalsIgnoreCase("clear")){
+                } else if (args.length == 2 && args[0].equalsIgnoreCase("clear")) {
                     return list(CleanTabCompleter.PLAYER_PLACEHOLDER, "[Name]");
                 } else {
                     return list();
@@ -219,13 +220,13 @@ public enum Command {
     CHANGE_REASON("ab.changeReason",
             "([0-9]+|(?i)(ban|mute) \\S+) .+",
             new CleanTabCompleter((user, args) -> {
-                if(args.length <= 1) {
+                if (args.length <= 1) {
                     return list("<ID>", "ban", "mute");
-                }else {
+                } else {
                     boolean playerTarget = args[0].equalsIgnoreCase("ban") || args[0].equalsIgnoreCase("mute");
-                    if(args.length == 2 && playerTarget){
+                    if (args.length == 2 && playerTarget) {
                         return list(CleanTabCompleter.PLAYER_PLACEHOLDER, "[Name]");
-                    } else if((playerTarget && args.length == 3) || args.length == 2){
+                    } else if ((playerTarget && args.length == 3) || args.length == 2) {
                         return list("new reason...");
                     } else {
                         return list();
@@ -283,9 +284,9 @@ public enum Command {
     HISTORY("ab.history",
             "\\S+( [1-9][0-9]*)?",
             new CleanTabCompleter((user, args) -> {
-                if(args.length == 1)
+                if (args.length == 1)
                     return list(CleanTabCompleter.PLAYER_PLACEHOLDER, "[Name]");
-                else if(args.length == 2)
+                else if (args.length == 2)
                     return list("<Page>");
                 else
                     return list();
@@ -299,12 +300,12 @@ public enum Command {
     WARNS(null,
             "\\S+( [1-9][0-9]*)?|\\S+|",
             new CleanTabCompleter((user, args) -> {
-                if(args.length == 1)
-                    if(Universal.get().getMethods().hasPerms(user, "ab.notes.other"))
+                if (args.length == 1)
+                    if (Universal.get().getMethods().hasPerms(user, "ab.notes.other"))
                         return list(CleanTabCompleter.PLAYER_PLACEHOLDER, "<Name>", "<Page>");
                     else
                         return list("<Page>");
-                else if(args.length == 2 && !args[0].matches("\\d+"))
+                else if (args.length == 2 && !args[0].matches("\\d+"))
                     return list("<Page>");
                 else
                     return list();
@@ -326,7 +327,7 @@ public enum Command {
                     }
 
                     String name = Universal.get().getMethods().getName(input.getSender());
-                    String identifier = processName(new Command.CommandInput(input.getSender(), new String[]{name}));
+                    String identifier = processName(new Command.CommandInput(input.getSender(), new String[] { name }));
                     new ListProcessor(
                             target -> PunishmentManager.get().getPunishments(identifier, PunishmentType.WARNING, true),
                             "WarnsOwn", false, false).accept(input);
@@ -337,12 +338,12 @@ public enum Command {
     NOTES(null,
             "\\S+( [1-9][0-9]*)?|\\S+|",
             new CleanTabCompleter((user, args) -> {
-                if(args.length == 1)
-                    if(Universal.get().getMethods().hasPerms(user, "ab.notes.other"))
+                if (args.length == 1)
+                    if (Universal.get().getMethods().hasPerms(user, "ab.notes.other"))
                         return list(CleanTabCompleter.PLAYER_PLACEHOLDER, "<Name>", "<Page>");
                     else
                         return list("<Page>");
-                else if(args.length == 2 && !args[0].matches("\\d+"))
+                else if (args.length == 2 && !args[0].matches("\\d+"))
                     return list("<Page>");
                 else
                     return list();
@@ -364,7 +365,7 @@ public enum Command {
                     }
 
                     String name = Universal.get().getMethods().getName(input.getSender());
-                    String identifier = processName(new Command.CommandInput(input.getSender(), new String[]{name}));
+                    String identifier = processName(new Command.CommandInput(input.getSender(), new String[] { name }));
                     new ListProcessor(
                             target -> PunishmentManager.get().getPunishments(identifier, PunishmentType.NOTE, true),
                             "NotesOwn", false, false).accept(input);
@@ -396,23 +397,30 @@ public enum Command {
                 boolean uuidCached = PunishmentManager.get().isCached(uuid);
 
                 Object sender = input.getSender();
-                MessageManager.sendMessage(sender, "Check.Header", true, "NAME", name, "CACHED", nameCached ? cached : notCached);
-                MessageManager.sendMessage(sender, "Check.UUID", false, "UUID", uuid, "CACHED", uuidCached ? cached : notCached);
+                MessageManager.sendMessage(sender, "Check.Header", true, "NAME", name, "CACHED",
+                        nameCached ? cached : notCached);
+                MessageManager.sendMessage(sender, "Check.UUID", false, "UUID", uuid, "CACHED",
+                        uuidCached ? cached : notCached);
                 if (Universal.get().hasPerms(sender, "ab.check.ip")) {
-                    MessageManager.sendMessage(sender, "Check.IP", false, "IP", ip, "CACHED", ipCached ? cached : notCached);
+                    MessageManager.sendMessage(sender, "Check.IP", false, "IP", ip, "CACHED",
+                            ipCached ? cached : notCached);
                 }
                 MessageManager.sendMessage(sender, "Check.Geo", false, "LOCATION", loc == null ? "failed!" : loc);
-                MessageManager.sendMessage(sender, "Check.Mute", false, "DURATION", mute == null ? "§anone" : mute.getType().isTemp() ? "§e" + mute.getDuration(false) : "§cperma");
+                MessageManager.sendMessage(sender, "Check.Mute", false, "DURATION",
+                        mute == null ? "§anone" : mute.getType().isTemp() ? "§e" + mute.getDuration(false) : "§cperma");
                 if (mute != null) {
                     MessageManager.sendMessage(sender, "Check.MuteReason", false, "REASON", mute.getReason());
                 }
-                MessageManager.sendMessage(sender, "Check.Ban", false, "DURATION", ban == null ? "§anone" : ban.getType().isTemp() ? "§e" + ban.getDuration(false) : "§cperma");
+                MessageManager.sendMessage(sender, "Check.Ban", false, "DURATION",
+                        ban == null ? "§anone" : ban.getType().isTemp() ? "§e" + ban.getDuration(false) : "§cperma");
                 if (ban != null) {
                     MessageManager.sendMessage(sender, "Check.BanReason", false, "REASON", ban.getReason());
                 }
-                MessageManager.sendMessage(sender, "Check.Warn", false, "COUNT", PunishmentManager.get().getCurrentWarns(uuid) + "");
+                MessageManager.sendMessage(sender, "Check.Warn", false, "COUNT",
+                        PunishmentManager.get().getCurrentWarns(uuid) + "");
 
-                MessageManager.sendMessage(sender, "Check.Note", false, "COUNT", PunishmentManager.get().getCurrentNotes(uuid) + "");
+                MessageManager.sendMessage(sender, "Check.Note", false, "COUNT",
+                        PunishmentManager.get().getCurrentNotes(uuid) + "");
             },
             "Check.Usage",
             "check"),
@@ -425,12 +433,14 @@ public enum Command {
                 Calendar calendar = new GregorianCalendar();
                 Object sender = input.getSender();
                 mi.sendMessage(sender, "§c§lAdvancedBan v2 §cSystemPrefs");
-                mi.sendMessage(sender, "§cServer-Time §8» §7" + calendar.get(Calendar.HOUR_OF_DAY) + ":" + calendar.get(Calendar.MINUTE));
+                mi.sendMessage(sender, "§cServer-Time §8» §7" + calendar.get(Calendar.HOUR_OF_DAY) + ":"
+                        + calendar.get(Calendar.MINUTE));
                 mi.sendMessage(sender, "§cYour UUID (Intern) §8» §7" + mi.getInternUUID(sender));
                 if (input.hasNext()) {
                     String target = input.getPrimaryData();
                     mi.sendMessage(sender, "§c" + target + "'s UUID (Intern) §8» §7" + mi.getInternUUID(target));
-                    mi.sendMessage(sender, "§c" + target + "'s UUID (Fetched) §8» §7" + UUIDManager.get().getUUID(target));
+                    mi.sendMessage(sender,
+                            "§c" + target + "'s UUID (Fetched) §8» §7" + UUIDManager.get().getUUID(target));
                 }
             },
             null,
@@ -506,19 +516,21 @@ public enum Command {
                     }
                 }
 
-
                 mi.sendMessage(sender, "§8§l§m-=====§r §c§lAdvancedBan v2 §8§l§m=====-§r ");
                 mi.sendMessage(sender, "  §cDev §8• §7Leoko");
                 mi.sendMessage(sender, "  §cStatus §8• §a§oStable");
                 mi.sendMessage(sender, "  §cVersion §8• §7" + mi.getVersion());
                 mi.sendMessage(sender, "  §cLicense §8• §7Public");
-                mi.sendMessage(sender, "  §cStorage §8• §7" + (DatabaseManager.get().isUseMySQL() ? "MySQL (external)" : "HSQLDB (local)"));
+                mi.sendMessage(sender, "  §cStorage §8• §7"
+                        + (DatabaseManager.get().isUseMySQL() ? "MySQL (external)" : "HSQLDB (local)"));
                 mi.sendMessage(sender, "  §cServer §8• §7" + Universal.get().getServerType().toString());
                 if (Universal.get().isProxy() && Universal.get().getServerType() == ServerType.BUNGEECORD) {
                     mi.sendMessage(sender, "  §cRedisBungee §8• §7" + (Universal.isRedis() ? "true" : "false"));
                 }
                 mi.sendMessage(sender, "  §cUUID-Mode §8• §7" + UUIDManager.get().getMode());
-                mi.sendMessage(sender, "  §cPrefix §8• §7" + (mi.getBoolean(mi.getConfig(), "Disable Prefix", false) ? "" : MessageManager.getMessage("General.Prefix")));
+                mi.sendMessage(sender,
+                        "  §cPrefix §8• §7" + (mi.getBoolean(mi.getConfig(), "Disable Prefix", false) ? ""
+                                : MessageManager.getMessage("General.Prefix")));
                 mi.sendMessage(sender, "§8§l§m-=========================-§r ");
             },
             null,
@@ -543,7 +555,8 @@ public enum Command {
 
     Command(String permission, String regex, TabCompleter tabCompleter, Consumer<CommandInput> commandHandler,
             String usagePath, String... names) {
-        this(permission, (args) -> String.join(" ", args).matches(regex), tabCompleter, commandHandler, usagePath, names);
+        this(permission, (args) -> String.join(" ", args).matches(regex), tabCompleter, commandHandler, usagePath,
+                names);
     }
 
     public boolean validateArguments(String[] args) {
@@ -554,9 +567,21 @@ public enum Command {
         commandHandler.accept(new CommandInput(player, args));
     }
 
-
-
     public TabCompleter getTabCompleter() {
+
+        MethodInterface mi = Universal.get().getMethods();
+
+        if (!mi.getBoolean(mi.getConfig(), "Use Tab Completion", true)) {
+
+            // Return an empty Tab completer as the tab completion was disabled in the config
+            return new TabCompleter() {
+
+                @Override
+                public List<String> onTabComplete(Object user, String[] args) {
+                    return new ArrayList<>();
+                }
+            };
+        }
         return tabCompleter;
     }
 

--- a/core/src/main/java/me/leoko/advancedban/utils/CommandUtils.java
+++ b/core/src/main/java/me/leoko/advancedban/utils/CommandUtils.java
@@ -47,10 +47,19 @@ public class CommandUtils {
         MethodInterface mi = Universal.get().getMethods();
         String reason = String.join(" ", input.getArgs());
 
-        if (reason.matches("[~@].+") && !mi.contains(mi.getLayouts(), "Message." + input.getPrimary().substring(1))) {
-            MessageManager.sendMessage(input.getSender(), "General.LayoutNotFound",
-                    true, "NAME", input.getPrimary().substring(1));
-            return null;
+        if (reason.matches("[~@].+")) {
+
+            if (!mi.getBoolean(mi.getLayouts(), "Use Message Layouts", true)) {
+                MessageManager.sendMessage(input.getSender(), "General.MessageLayoutsDisabled", true);
+                return null;
+            }
+
+            if (!mi.contains(mi.getLayouts(), "Message." + input.getPrimary().substring(1))) {
+                MessageManager.sendMessage(input.getSender(), "General.LayoutNotFound",
+                true, "NAME", input.getPrimary().substring(1));
+                return null;
+            }
+
         }
 
         return reason;

--- a/core/src/main/java/me/leoko/advancedban/utils/commands/PunishmentProcessor.java
+++ b/core/src/main/java/me/leoko/advancedban/utils/commands/PunishmentProcessor.java
@@ -83,6 +83,10 @@ public class PunishmentProcessor implements Consumer<Command.CommandInput> {
         input.next();
         MethodInterface mi = Universal.get().getMethods();
         if (time.matches("#.+")) {
+            if (!mi.getBoolean(mi.getLayouts(), "Use Time Layouts", true)) {
+                MessageManager.sendMessage(input.getSender(), "General.TimeLayoutsDisabled", true);
+                return null;
+        }
             String layout = time.substring(1);
             if (!mi.contains(mi.getLayouts(), "Time." + layout)) {
                 MessageManager.sendMessage(input.getSender(), "General.LayoutNotFound", true, "NAME", layout);

--- a/core/src/main/java/me/leoko/advancedban/utils/commands/PunishmentProcessor.java
+++ b/core/src/main/java/me/leoko/advancedban/utils/commands/PunishmentProcessor.java
@@ -86,7 +86,7 @@ public class PunishmentProcessor implements Consumer<Command.CommandInput> {
             if (!mi.getBoolean(mi.getLayouts(), "Use Time Layouts", true)) {
                 MessageManager.sendMessage(input.getSender(), "General.TimeLayoutsDisabled", true);
                 return null;
-            }
+        }
             String layout = time.substring(1);
             if (!mi.contains(mi.getLayouts(), "Time." + layout)) {
                 MessageManager.sendMessage(input.getSender(), "General.LayoutNotFound", true, "NAME", layout);

--- a/core/src/main/java/me/leoko/advancedban/utils/commands/PunishmentProcessor.java
+++ b/core/src/main/java/me/leoko/advancedban/utils/commands/PunishmentProcessor.java
@@ -86,7 +86,7 @@ public class PunishmentProcessor implements Consumer<Command.CommandInput> {
             if (!mi.getBoolean(mi.getLayouts(), "Use Time Layouts", true)) {
                 MessageManager.sendMessage(input.getSender(), "General.TimeLayoutsDisabled", true);
                 return null;
-        }
+            }
             String layout = time.substring(1);
             if (!mi.contains(mi.getLayouts(), "Time." + layout)) {
                 MessageManager.sendMessage(input.getSender(), "General.LayoutNotFound", true, "NAME", layout);

--- a/core/src/main/java/me/leoko/advancedban/utils/tabcompletion/PunishmentTabCompleter.java
+++ b/core/src/main/java/me/leoko/advancedban/utils/tabcompletion/PunishmentTabCompleter.java
@@ -20,10 +20,6 @@ public class PunishmentTabCompleter implements TabCompleter {
         final MethodInterface methodInterface = Universal.get().getMethods();
 
         List<String> suggestions = new ArrayList<>();
-        
-        if (!methodInterface.getBoolean(methodInterface.getConfig(), "Use Tab Completion", true)) {
-            return suggestions;
-        }
 
         boolean hiddenTag = false;
         if(args.length > 1 && args[0].equalsIgnoreCase("-s")) {
@@ -57,11 +53,13 @@ public class PunishmentTabCompleter implements TabCompleter {
             }
 
         } else if((temporary && args.length == 3) || args.length == 2) {
+            suggestions.add("Reason...");
             if (methodInterface.getBoolean(methodInterface.getLayouts(), "Use Message Layouts", true)) {
-                suggestions.add("Reason...");
+
                 for (String layout : methodInterface.getKeys(methodInterface.getLayouts(), "Message")) {
                     suggestions.add("@"+layout);
                 }
+
             }
 
         }

--- a/core/src/main/java/me/leoko/advancedban/utils/tabcompletion/PunishmentTabCompleter.java
+++ b/core/src/main/java/me/leoko/advancedban/utils/tabcompletion/PunishmentTabCompleter.java
@@ -20,6 +20,10 @@ public class PunishmentTabCompleter implements TabCompleter {
         final MethodInterface methodInterface = Universal.get().getMethods();
 
         List<String> suggestions = new ArrayList<>();
+        
+        if (!methodInterface.getBoolean(methodInterface.getConfig(), "Use Tab Completion", true)) {
+            return suggestions;
+        }
 
         boolean hiddenTag = false;
         if(args.length > 1 && args[0].equalsIgnoreCase("-s")) {
@@ -53,9 +57,8 @@ public class PunishmentTabCompleter implements TabCompleter {
             }
 
         } else if((temporary && args.length == 3) || args.length == 2) {
-            suggestions.add("Reason...");
             if (methodInterface.getBoolean(methodInterface.getLayouts(), "Use Message Layouts", true)) {
-                
+                suggestions.add("Reason...");
                 for (String layout : methodInterface.getKeys(methodInterface.getLayouts(), "Message")) {
                     suggestions.add("@"+layout);
                 }

--- a/core/src/main/java/me/leoko/advancedban/utils/tabcompletion/PunishmentTabCompleter.java
+++ b/core/src/main/java/me/leoko/advancedban/utils/tabcompletion/PunishmentTabCompleter.java
@@ -20,10 +20,6 @@ public class PunishmentTabCompleter implements TabCompleter {
         final MethodInterface methodInterface = Universal.get().getMethods();
 
         List<String> suggestions = new ArrayList<>();
-        
-        if (!methodInterface.getBoolean(methodInterface.getConfig(), "Use Tab Completion", true)) {
-            return suggestions;
-        }
 
         boolean hiddenTag = false;
         if(args.length > 1 && args[0].equalsIgnoreCase("-s")) {
@@ -57,8 +53,9 @@ public class PunishmentTabCompleter implements TabCompleter {
             }
 
         } else if((temporary && args.length == 3) || args.length == 2) {
+            suggestions.add("Reason...");
             if (methodInterface.getBoolean(methodInterface.getLayouts(), "Use Message Layouts", true)) {
-                suggestions.add("Reason...");
+                
                 for (String layout : methodInterface.getKeys(methodInterface.getLayouts(), "Message")) {
                     suggestions.add("@"+layout);
                 }

--- a/core/src/main/java/me/leoko/advancedban/utils/tabcompletion/PunishmentTabCompleter.java
+++ b/core/src/main/java/me/leoko/advancedban/utils/tabcompletion/PunishmentTabCompleter.java
@@ -20,6 +20,10 @@ public class PunishmentTabCompleter implements TabCompleter {
         final MethodInterface methodInterface = Universal.get().getMethods();
 
         List<String> suggestions = new ArrayList<>();
+        
+        if (!methodInterface.getBoolean(methodInterface.getConfig(), "Use Tab Completion", true)) {
+            return suggestions;
+        }
 
         boolean hiddenTag = false;
         if(args.length > 1 && args[0].equalsIgnoreCase("-s")) {
@@ -46,14 +50,20 @@ public class PunishmentTabCompleter implements TabCompleter {
                     suggestions.add(amount + unit);
                 }
             }
-            for (String layout : methodInterface.getKeys(methodInterface.getLayouts(), "Time")) {
-                suggestions.add("#"+layout);
+            if (methodInterface.getBoolean(methodInterface.getLayouts(), "Use Time Layouts")) {
+                for (String layout : methodInterface.getKeys(methodInterface.getLayouts(), "Time")) {
+                    suggestions.add("#"+layout);
+                }
             }
+
         } else if((temporary && args.length == 3) || args.length == 2) {
-            suggestions.add("Reason...");
-            for (String layout : methodInterface.getKeys(methodInterface.getLayouts(), "Message")) {
-                suggestions.add("@"+layout);
+            if (methodInterface.getBoolean(methodInterface.getLayouts(), "Use Message Layouts", true)) {
+                suggestions.add("Reason...");
+                for (String layout : methodInterface.getKeys(methodInterface.getLayouts(), "Message")) {
+                    suggestions.add("@"+layout);
+                }
             }
+
         }
 
         if(args.length > 0){

--- a/core/src/main/resources/Layouts.yml
+++ b/core/src/main/resources/Layouts.yml
@@ -1,5 +1,4 @@
 # The default layouts are in the Message.yml file!
-
 # Message-Layouts can not only be used for bans but also for mutes and warns
 # Currently available variables:
 #   %OPERATOR% - The user who dealt the punishment.
@@ -12,6 +11,13 @@
 # For warns you have also the variable %COUNT% which will be
 # replaced with the current amount of warns the player already received
 # Example usage: /ban Leoko @ExampleLayout
+
+# Use Message Layouts (If disabled, this will disable Tab-completion of Message Layouts aswell. Any entries within the Message section will be ignored)
+Use Message Layouts: true
+
+# Use Time Layouts (If disabled, this will disable Tab-completion of Time Layouts aswell. Any entries within the Time section will be ignored)
+Use Time Layouts: true
+
 Message:
   ExampleLayout:
     - '%PREFIX% &7Banned for Hacking'

--- a/core/src/main/resources/Layouts.yml
+++ b/core/src/main/resources/Layouts.yml
@@ -15,7 +15,7 @@
 # Use Message Layouts (If disabled, this will disable Tab-completion of Message Layouts aswell. Any entries within the Message section will be ignored)
 Use Message Layouts: true
 
-# Use Time Layouts (If disabled, this will disable Tab-completion of Time Layouts aswell. Any entries within the Time section will be ignored)
+# Use Time Layouts (If disabled, this will disable Tab-completion of Time Layouts as well. Any entries within the Time section will be ignored)
 Use Time Layouts: true
 
 Message:

--- a/core/src/main/resources/Layouts.yml
+++ b/core/src/main/resources/Layouts.yml
@@ -12,7 +12,7 @@
 # replaced with the current amount of warns the player already received
 # Example usage: /ban Leoko @ExampleLayout
 
-# Use Message Layouts (If disabled, this will disable Tab-completion of Message Layouts aswell. Any entries within the Message section will be ignored)
+# Use Message Layouts (If disabled, this will disable Tab-completion of Message Layouts as well. Any entries within the Message section will be ignored)
 Use Message Layouts: true
 
 # Use Time Layouts (If disabled, this will disable Tab-completion of Time Layouts as well. Any entries within the Time section will be ignored)

--- a/core/src/main/resources/Messages.yml
+++ b/core/src/main/resources/Messages.yml
@@ -2,6 +2,8 @@ General:
   Prefix: "&c&lAdvancedBan &8&l»"
   NoPerms: "&cYou don't have perms for that!"
   LayoutNotFound: "&cThere is no layout called %NAME%"
+  TimeLayoutsDisabled: "&cThe use of time layouts has been disabled"
+  MessageLayoutsDisabled: "&cThe use of message layouts has been disabled"
   # This will be the replacement for the %DURATION% variable
   TimeLayoutD: "%D%day(s) %H%h %M%min and %S%sec"
   TimeLayoutH: "%H%hour(s) %M%min and %S%sec"

--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -143,3 +143,13 @@ Disable Prefix: false
 # Off by default, so AdvancedBan can override /ban from other plugins
 # This is a Bukkit-specific option. It has no meaning on BungeeCord
 Friendly Register Commands: false
+
+# Disable Tab-Completion entirely
+# This will disable everything Tab-Completion related on AdvancedBan, such as:
+# - Layout Tab Completion (@Layout)
+# - Time Layout Tab Completion (#Time)
+# - Options Tab Completion (-s for example)
+# - Player Autocompletion
+
+# If you wish to only disable tab-completion for layouts, check out the Layouts.yml file under "Use Message Layouts" and "Use Time Layouts"
+Use Tab Completion: true

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     
     <groupId>me.leoko.advancedban</groupId>
     <artifactId>AdvancedBan</artifactId>
-    <version>2.4.0</version>
+    <version>2.4.1</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/velocity/pom.xml
+++ b/velocity/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>me.leoko.advancedban</groupId>
         <artifactId>AdvancedBan</artifactId>
-        <version>2.4.0</version>
+        <version>2.4.1</version>
     </parent>
 
     <artifactId>AdvancedBan-Velocity</artifactId>


### PR DESCRIPTION
This Pull-Request includes new configuration settings to disable the use of Layouts, aswell as disabling Tab-completion. Disabling Tab-completion was previously only doable by using a plugin that fully disables tab completion. 

The configuration file "config.yml" has a new section called "Use Tab Completion". This setting allows administrators to entirely disable Tab completion from AdvancedBan. This includes tab-completing users, Options and Layouts. To allow legacy configuration files, this setting is set to true by default.

The configuration file "Layouts.yml" has 2 new options called "Use Message Layouts" and "Use Time Layouts". Disabling either of them will remove Layouts from both Tab-completion, aswell as the use of it entirely. Trying to use it will respond with a message defined within the "Messages.yml" under the sections "TimeLayoutsDisabled" and "MessageLayoutsDisabled". These sections will cause issues if not present, but would not be used if Layouts are enabled by default (aka using previous configuration files). Administrators can append said sections accordingly.

As already mentioned, this should mostly not cause issues with legacy versions of configuration files, but may cause issues if "MessageLayoutsDisabled" or "TimeLayoutsDisabled" are not present. But again, this should not cause any issues through default use and can be appended by Administrators if needed.

Cheers.