### PR TITLE
Add CloudnetV4 support and maven depedency fix

### DIFF
--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -56,6 +56,10 @@
                             <pattern>org.bstats</pattern>
                             <shadedPattern>${project.groupId}.shaded.org.bstats</shadedPattern>
                         </relocation>
+                        <relocation>
+                            <pattern>com.google.common</pattern>
+                            <shadedPattern>${project.groupId}.shaded.com.google.common</shadedPattern>
+                        </relocation>
                     </relocations>
                     <transformers>
                         <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>

--- a/bungee/pom.xml
+++ b/bungee/pom.xml
@@ -38,14 +38,24 @@
             <id>CodeMC</id>
             <url>https://repo.codemc.org/repository/maven-public</url>
         </repository>
+        <repository>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
+        </repository>
     </repositories>
 
     <dependencies>
         <dependency>
             <groupId>net.md-5</groupId>
             <artifactId>bungeecord-api</artifactId>
-            <version>1.12-SNAPSHOT</version>
+            <version>1.19-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>31.1-jre</version>
         </dependency>
 
         <!-- CloudNet v3-->
@@ -80,14 +90,14 @@
         <dependency>
             <groupId>net.luckperms</groupId>
             <artifactId>api</artifactId>
-            <version>5.2</version>
+            <version>5.4</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
-            <groupId>com.imaginarycode.minecraft</groupId>
+            <groupId>com.github.minecrafter</groupId>
             <artifactId>RedisBungee</artifactId>
-            <version>0.3.6-SNAPSHOT</version>
+            <version>master-934e4543d6-1</version>
             <scope>provided</scope>
         </dependency>
 

--- a/bungee/pom.xml
+++ b/bungee/pom.xml
@@ -87,6 +87,20 @@
             <scope>provided</scope>
         </dependency>
 
+        <!-- CloudNet V4 -->
+        <dependency>
+            <groupId>eu.cloudnetservice.cloudnet</groupId>
+            <artifactId>bridge</artifactId>
+            <version>4.0.0-RC5</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>eu.cloudnetservice.cloudnet</groupId>
+            <artifactId>driver</artifactId>
+            <version>4.0.0-RC5</version>
+            <scope>provided</scope>
+        </dependency>
+
         <dependency>
             <groupId>net.luckperms</groupId>
             <artifactId>api</artifactId>

--- a/bungee/src/main/java/me/leoko/advancedban/bungee/cloud/CloudSupportHandler.java
+++ b/bungee/src/main/java/me/leoko/advancedban/bungee/cloud/CloudSupportHandler.java
@@ -2,14 +2,24 @@ package me.leoko.advancedban.bungee.cloud;
 
 import me.leoko.advancedban.bungee.cloud.support.CloudNetV2Support;
 import me.leoko.advancedban.bungee.cloud.support.CloudNetV3Support;
+import me.leoko.advancedban.bungee.cloud.support.CloudNetV4Support;
 import net.md_5.bungee.api.ProxyServer;
 
 public class CloudSupportHandler {
 
     public static CloudSupport getCloudSystem(){
-        if (ProxyServer.getInstance().getPluginManager().getPlugin("CloudNet-Bridge") != null)  {
-            return new CloudNetV3Support();
-        }
+        try {
+            if (ProxyServer.getInstance().getPluginManager().getPlugin("CloudNet-Bridge") != null) {
+                Class.forName("de.dytanic.cloudnet.driver.CloudNetDriver");
+                return new CloudNetV3Support();
+            }
+        } catch (ClassNotFoundException ignored) {}
+        try {
+            if (ProxyServer.getInstance().getPluginManager().getPlugin("CloudNet-Bridge") != null) {
+                Class.forName("eu.cloudnetservice.driver.CloudNetDriver");
+                return new CloudNetV4Support();
+            }
+        } catch (ClassNotFoundException ignored) {}
         if (ProxyServer.getInstance().getPluginManager().getPlugin("CloudNetAPI") != null) {
             return new CloudNetV2Support();
         }

--- a/bungee/src/main/java/me/leoko/advancedban/bungee/cloud/support/CloudNetV4Support.java
+++ b/bungee/src/main/java/me/leoko/advancedban/bungee/cloud/support/CloudNetV4Support.java
@@ -1,0 +1,20 @@
+package me.leoko.advancedban.bungee.cloud.support;
+
+import eu.cloudnetservice.driver.CloudNetDriver;
+import eu.cloudnetservice.modules.bridge.player.PlayerManager;
+import me.leoko.advancedban.bungee.cloud.CloudSupport;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
+
+import java.util.Objects;
+import java.util.UUID;
+
+public class CloudNetV4Support implements CloudSupport {
+    @Override
+    public void kick(UUID uniqueID, String reason) {
+        Objects.requireNonNull(CloudNetDriver.instance().serviceRegistry()
+                        .firstProvider(PlayerManager.class)
+                        .onlinePlayer(uniqueID),"player is null in CloudNetV4")
+                .playerExecutor()
+                .kick(LegacyComponentSerializer.legacySection().deserialize(reason));
+    }
+}


### PR DESCRIPTION
- kick player using cloudnet v4 instant of bungeecord (like version 3 and 2 support)
  - fix player not kicked when using cloudnet v4
- updated maven dependencies necessary to compile

### CloudnetV4 is at the moment of this pull request still in release candidate state. It's still possible that the API changes, however I consider it as very unlikely.