### PR TITLE
fix issue #646

### DIFF
--- a/core/src/main/java/me/leoko/advancedban/utils/commands/ListProcessor.java
+++ b/core/src/main/java/me/leoko/advancedban/utils/commands/ListProcessor.java
@@ -53,7 +53,7 @@ public class ListProcessor implements Consumer<Command.CommandInput> {
 
         punishments
                 .stream()
-                .filter(punishment -> punishment.isExpired() && !history)
+                .filter(punishment -> punishment != null && punishment.isExpired() && !history)
                 .forEach(punishment -> {
                     punishment.delete();
                     punishments.remove(punishment);


### PR DESCRIPTION
This is temp solution. It will not fix the main issue - how nullable object even got into the punishment list, but this solution allows command /banlist to continue it's execution even if it will happend again. 