### PR TITLE
Fix NPE when banning/unbanning person that isn't known

### DIFF
--- a/bukkit/src/main/java/me/leoko/advancedban/bukkit/listener/InternalListener.java
+++ b/bukkit/src/main/java/me/leoko/advancedban/bukkit/listener/InternalListener.java
@@ -15,28 +15,44 @@ import java.util.Date;
  * @author Beelzebu
  */
 public class InternalListener implements Listener {
-    
+
+    private void ban(BanList banlist, PunishmentEvent e) {
+        try {
+            banlist.addBan(e.getPunishment().getName(), e.getPunishment().getReason(), new Date(e.getPunishment().getEnd()), e.getPunishment().getOperator());
+        } catch (NullPointerException ex) {
+            Bukkit.getLogger().severe("No player is known by the name '" + e.getPunishment().getName() + "'");
+        }
+    }
+
     @EventHandler
     public void onPunish(PunishmentEvent e) {
         BanList banlist;
         if (e.getPunishment().getType().equals(PunishmentType.BAN) || e.getPunishment().getType().equals(PunishmentType.TEMP_BAN)) {
             banlist = Bukkit.getBanList(BanList.Type.NAME);
-            banlist.addBan(e.getPunishment().getName(), e.getPunishment().getReason(), new Date(e.getPunishment().getEnd()), e.getPunishment().getOperator());
+            ban(banlist, e);
         } else if (e.getPunishment().getType().equals(PunishmentType.IP_BAN) || e.getPunishment().getType().equals(PunishmentType.TEMP_IP_BAN)) {
             banlist = Bukkit.getBanList(BanList.Type.IP);
-            banlist.addBan(e.getPunishment().getName(), e.getPunishment().getReason(), new Date(e.getPunishment().getEnd()), e.getPunishment().getOperator());
+            ban(banlist, e);
         }
     }
-    
+
+    private void pardon(BanList banlist, RevokePunishmentEvent e) {
+        try {
+            banlist.pardon(e.getPunishment().getName());
+        } catch (NullPointerException ex) {
+            Bukkit.getLogger().severe("No player is known by the name '" + e.getPunishment().getName() + "'");
+        }
+    }
+
     @EventHandler
     public void onRevokePunishment(RevokePunishmentEvent e) {
         BanList banlist;
         if (e.getPunishment().getType().equals(PunishmentType.BAN) || e.getPunishment().getType().equals(PunishmentType.TEMP_BAN)) {
             banlist = Bukkit.getBanList(BanList.Type.NAME);
-            banlist.pardon(e.getPunishment().getName());
+            pardon(banlist, e);
         } else if (e.getPunishment().getType().equals(PunishmentType.IP_BAN) || e.getPunishment().getType().equals(PunishmentType.TEMP_IP_BAN)) {
             banlist = Bukkit.getBanList(BanList.Type.IP);
-            banlist.pardon(e.getPunishment().getName());
+            pardon(banlist, e);
         }
     }
 }


### PR DESCRIPTION
So when the player isn't known, you can ban them, but when pardoning them, it will give a NPE.
This fix resolves that nasty error and shows a nicer error message.

Closes #650 

Before:
```
[16:52:43] [Server thread/ERROR]: Could not pass event RevokePunishmentEvent to AdvancedBan v2.3.0
java.lang.NullPointerException: Cannot invoke "com.mojang.authlib.GameProfile.getId()" because "gameProfile" is null
 at net.minecraft.server.players.UserBanList.getKeyForUser(UserBanList.java:29) ~[paper-1.21.jar:1.21-106-3a47518]
 at net.minecraft.server.players.UserBanList.getKeyForUser(UserBanList.java:10) ~[paper-1.21.jar:1.21-106-3a47518]
 at net.minecraft.server.players.StoredUserList.remove(StoredUserList.java:64) ~[paper-1.21.jar:1.21-106-3a47518]
 at org.bukkit.craftbukkit.ban.CraftProfileBanList.pardon(CraftProfileBanList.java:193) ~[paper-1.21.jar:1.21-106-3a47518]
 at org.bukkit.craftbukkit.ban.CraftProfileBanList.pardon(CraftProfileBanList.java:162) ~[paper-1.21.jar:1.21-106-3a47518]
 at AdvancedBan-Bundle-2.3.0-RELEASE.jar/me.leoko.advancedban.bukkit.listener.InternalListener.onRevokePunishment(InternalListener.java:36) ~[AdvancedBan-Bundle-2.3.0-RELEASE.jar:?]
 at com.destroystokyo.paper.event.executor.asm.generated.GeneratedEventExecutor123.execute(Unknown Source) ~[?:?]
 at org.bukkit.plugin.EventExecutor$2.execute(EventExecutor.java:77) ~[paper-api-1.21-R0.1-SNAPSHOT.jar:?]
 at co.aikar.timings.TimedEventExecutor.execute(TimedEventExecutor.java:80) ~[paper-api-1.21-R0.1-SNAPSHOT.jar:1.21-106-3a47518]
 at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:70) ~[paper-api-1.21-R0.1-SNAPSHOT.jar:?]
 at io.papermc.paper.plugin.manager.PaperEventManager.callEvent(PaperEventManager.java:54) ~[paper-1.21.jar:1.21-106-3a47518]
 at io.papermc.paper.plugin.manager.PaperPluginManagerImpl.callEvent(PaperPluginManagerImpl.java:131) ~[paper-1.21.jar:1.21-106-3a47518]
 at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:628) ~[paper-api-1.21-R0.1-SNAPSHOT.jar:?]
 at AdvancedBan-Bundle-2.3.0-RELEASE.jar/me.leoko.advancedban.bukkit.BukkitMethods.lambda$callRevokePunishmentEvent$8(BukkitMethods.java:375) ~[AdvancedBan-Bun...
```

After:
```
No player is known by the name '...'
```
