### PR TITLE
Fix version update check

### DIFF
--- a/core/src/main/java/me/leoko/advancedban/Universal.java
+++ b/core/src/main/java/me/leoko/advancedban/Universal.java
@@ -88,7 +88,7 @@ public class Universal {
         String response = getFromURL("https://api.spigotmc.org/legacy/update.php?resource=8695");
         if (response == null) {
             upt = "Failed to check for updates :(";
-        } else if ((!mi.getVersion().startsWith(response))) {
+        } else if ((!mi.getVersion().startsWith(response.replace("[", "").replace("]", "")))) {
             upt = "There is a new version available! [" + response + "]";
         }
 


### PR DESCRIPTION
Remove square brackets from API response before comparing it with the installed version.
Example: from "[3.6.0]" to "3.6.0".